### PR TITLE
chore: codeowners -> hammer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/hammer


### PR DESCRIPTION
This PR adds team hammer as codeowners.