### PR TITLE
fix: use correct path separator in windows environment

### DIFF
--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/ProcessRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/ProcessRunner.java
@@ -56,7 +56,7 @@ public class ProcessRunner {
 	public ProcessBuilder createWinProcessBuilder(String command, Optional<String> path) {
 		if (command.startsWith("/")) command = command.replaceFirst("/", "");
 		ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", command);
-		pb.environment().put("PATH", path.map(p -> p+":"+DEFAULT_WIN_PATH).orElse(DEFAULT_WIN_PATH) + File.pathSeparator + System.getenv("PATH"));
+		pb.environment().put("PATH", path.map(p -> p+";"+DEFAULT_WIN_PATH).orElse(DEFAULT_WIN_PATH) + File.pathSeparator + System.getenv("PATH"));
 		return pb;
 	}
 


### PR DESCRIPTION
This PR fixes issue when a build tool is not in env.PATH and configured via plugin properties.
Windows uses semicolon (`;`) as path separator and not colon (`;`).