### PR TITLE
fix: make API token textfield editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can use Snyk for free on your Java, Scala, JavaScript .Net, Ruby projects an
 
 ## Download
 - Manual downloads : https://github.com/snyk/snyk-eclipse-plugin/releases
-- Eclipse market place (recommanded): https://marketplace.eclipse.org/content/snyk-vuln-scanner
+- Eclipse market place (recommended): https://marketplace.eclipse.org/content/snyk-vuln-scanner
 
 ## Supported Eclipse versions
 - 2019-09 (4.13)

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/AuthButtonFieldEditor.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/AuthButtonFieldEditor.java
@@ -16,7 +16,8 @@ public class AuthButtonFieldEditor extends StringButtonFieldEditor{
             Composite parent) {
         super(name, labelText, parent);
         setChangeButtonText("Authenticate");
-        getTextControl().setEditable(false);
+        // workaround: enable token textfield until issue with SSO is solved
+        // getTextControl().setEditable(false);
     }
 
 	@Override


### PR DESCRIPTION
This PR makes `Snyk API Token` text field editable.
This is a temporary workaround: we allow users to enter their API token and persist it when settings are saved.