### PR TITLE
fix: use double quotes when creating win process

### DIFF
--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
@@ -121,7 +121,7 @@ public class SnykCliRunner {
 			runnable = getRunnableLocation(SNYK_CLI_WIN);
 			// workaround: use quotes for every param until we rewrite ProcessRunner
 			String quotedParamsString = Arrays.stream(paramsString.split(" ")).collect(Collectors.joining("\" \"", "\"", "\""));
-			processbuilder= processRunner.createWinProcessBuilder("\"" + runnable + "\" " + quotedParamsString, path);
+			processbuilder = processRunner.createWinProcessBuilder("\"" + runnable + "\" " + quotedParamsString, path);
 		} else {
 			throw new NotSupportedException("This operating system is not supported");
 		}

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -118,7 +119,9 @@ public class SnykCliRunner {
 			processbuilder= processRunner.createLinuxProcessBuilder(runnable + " " + paramsString, path);
 		} else if (SystemUtils.IS_OS_WINDOWS) {
 			runnable = getRunnableLocation(SNYK_CLI_WIN);
-			processbuilder= processRunner.createWinProcessBuilder(runnable + " " + paramsString, path);
+			// workaround: use quotes for every param until we rewrite ProcessRunner
+			String quotedParamsString = Arrays.stream(paramsString.split(" ")).collect(Collectors.joining("\" \"", "\"", "\""));
+			processbuilder= processRunner.createWinProcessBuilder("\"" + runnable + "\" " + quotedParamsString, path);
 		} else {
 			throw new NotSupportedException("This operating system is not supported");
 		}

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/views/DataProvider.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/views/DataProvider.java
@@ -17,10 +17,17 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +45,9 @@ import io.snyk.eclipse.plugin.utils.Lists;
 
 public class DataProvider {
 	
+	private static final Bundle BUNDLE = FrameworkUtil.getBundle(DataProvider.class);
+	private static final ILog LOG = Platform.getLog(BUNDLE);
+
 	public static final  DataProvider INSTANCE = new DataProvider();
 
 	public static final AtomicBoolean abort = new AtomicBoolean(false);
@@ -174,7 +184,12 @@ public class DataProvider {
 
 	private DisplayModel processResult(ProcessResult result, IProject project, Optional<String> fileName) {
 		String projectName = project.getName();
-		
+
+		IStatus[] statuses = new IStatus[] {
+			new Status(Status.INFO, BUNDLE.getSymbolicName(), "result = " + result.getContent())
+		};
+		MultiStatus multiStatusResult = new MultiStatus(BUNDLE.getSymbolicName(), Status.INFO, statuses, "Snyk command result", null);
+		LOG.log(multiStatusResult);
 		
 		try {
 			DisplayModel projectModel;


### PR DESCRIPTION
This PR provides a fix for Windows users in case Eclipse is installed in a folder with whitespaces (e.g. `Program Files`).
How to use quotes in CMD -> https://ss64.com/nt/cmd.html
