### PR TITLE
fix: provide token and custom endpoint via environment variables

### DIFF
--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/AuthButtonFieldEditor.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/AuthButtonFieldEditor.java
@@ -22,16 +22,18 @@ public class AuthButtonFieldEditor extends StringButtonFieldEditor{
 
 	@Override
 	protected String changePressed() {
-		try {
-			PreferencesPage page = (PreferencesPage) getPage();
-			page.persist();
-		
-			return Authenticator.INSTANCE.callLogin();
-		} catch (AuthException e) {
-			e.printStackTrace();
-			MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Authentication", e.getMessage());
-			return null;
-		}
+		MessageDialog.openInformation(null, "Authentication", "Please enter your Snyk API Token into the text field");
+		return null;
+//		try {
+//			PreferencesPage page = (PreferencesPage) getPage();
+//			page.persist();
+//
+//			return Authenticator.INSTANCE.callLogin();
+//		} catch (AuthException e) {
+//			e.printStackTrace();
+//			MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Authentication", e.getMessage());
+//			return null;
+//		}
 	}
 	
 	public void emptyTextfield() {

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/PreferencesPage.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/properties/PreferencesPage.java
@@ -26,15 +26,16 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 	}
 	
 	private void handlePropertyChange(PropertyChangeEvent event) {
-		if (event.getProperty().equals(Preferences.ENDPOINT_KEY)) {
-			String newEndpoint = event.getNewValue().toString();
-			if (newEndpoint.isEmpty()) {
-				cliRunner.snykUnsetEndpoint();
-			} else {
-				cliRunner.snykSetEndpoint(newEndpoint);
-			}			
-			tokenField.emptyTextfield();
-		}
+		// don't run 'snyk config' command, so we use settings from eclipse prefs only
+//		if (event.getProperty().equals(Preferences.ENDPOINT_KEY)) {
+//			String newEndpoint = event.getNewValue().toString();
+//			if (newEndpoint.isEmpty()) {
+//				cliRunner.snykUnsetEndpoint();
+//			} else {
+//				cliRunner.snykSetEndpoint(newEndpoint);
+//			}
+//			tokenField.emptyTextfield();
+//		}
 	}
 
 	@Override

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/Authenticator.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/Authenticator.java
@@ -45,7 +45,7 @@ public class Authenticator {
 	private SnykCliRunner cliRunner = new SnykCliRunner();
 	ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-	public boolean isAuthenticated() throws AuthException {
+	private boolean isAuthenticated() throws AuthException {
 		if (MOCK)
 			return true;
 
@@ -66,25 +66,26 @@ public class Authenticator {
 		return false;
 	}
 
-	public void auth() throws AuthException {
-		ProcessResult procesResult = cliRunner.snykAuth();
-		if (procesResult.hasError()) {
-			throw new AuthException(procesResult.getError());
-		}
-
-		String content = procesResult.getContent();
-		if (content != null && content.contains("failed")) {
-			throw new AuthException(procesResult.getContent());
-		}
+	private void auth() throws AuthException {
+		// don't authenticate using 'snyk auth'
+//		ProcessResult procesResult = cliRunner.snykAuth();
+//		if (procesResult.hasError()) {
+//			throw new AuthException(procesResult.getError());
+//		}
+//
+//		String content = procesResult.getContent();
+//		if (content != null && content.contains("failed")) {
+//			throw new AuthException(procesResult.getContent());
+//		}
 	}
 
-	public void doAuthentication() throws AuthException {
+	private void doAuthentication() throws AuthException {
 		if (!isAuthenticated())
 			auth();
 	}
 
 	// call login url and do callback
-	public String callLogin() throws AuthException {
+	private String callLogin() throws AuthException {
 		String newToken = UUID.randomUUID().toString();
 
 		String loginUri = new StringBuilder(getAuthUrlBase()).append("/login?token=").append(newToken)
@@ -154,7 +155,7 @@ public class Authenticator {
 	    return client;
 	}
 
-	public String getAuthUrlBase() throws AuthException {
+	private String getAuthUrlBase() throws AuthException {
 		String customEndpoint = Preferences.getEndpoint();
 		if (customEndpoint == null || customEndpoint.isEmpty()) {
 			return API_URL;

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/ProcessRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/ProcessRunner.java
@@ -14,11 +14,15 @@ import org.eclipse.core.runtime.Status;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
+import io.snyk.eclipse.plugin.properties.Preferences;
+
 public class ProcessRunner {
 	
 	private static final Bundle BUNDLE = FrameworkUtil.getBundle(ProcessRunner.class);
 	private static final ILog LOG = Platform.getLog(BUNDLE);
 
+	private static final String ENV_SNYK_API = "SNYK_API";
+	private static final String ENV_SNYK_TOKEN = "SNYK_TOKEN";
 	private static final String DEFAULT_MAC_PATH = "/usr/local/bin";
 	private static final String DEFAULT_LINUX_PATH = "/usr/bin";
 	private static final String DEFAULT_WIN_PATH = "";
@@ -54,12 +58,22 @@ public class ProcessRunner {
 	
 	public ProcessBuilder createLinuxProcessBuilder(String command, Optional<String> path) {
 		ProcessBuilder pb = new ProcessBuilder("sh", "-c", command);
+		String endpoint = Preferences.getEndpoint();
+		if (endpoint != null && !endpoint.isEmpty()) {
+			pb.environment().put(ENV_SNYK_API, endpoint);
+		}
+		pb.environment().put(ENV_SNYK_TOKEN, Preferences.getAuthToken());
 		pb.environment().put("PATH", path.map(p -> p+":"+DEFAULT_LINUX_PATH).orElse(DEFAULT_LINUX_PATH) + File.pathSeparator + System.getenv("PATH"));
 		return pb;
 	}
 	
 	public ProcessBuilder createMacProcessBuilder(String command, Optional<String> path) {
 		ProcessBuilder pb = new ProcessBuilder("sh", "-c", command);
+		String endpoint = Preferences.getEndpoint();
+		if (endpoint != null && !endpoint.isEmpty()) {
+			pb.environment().put(ENV_SNYK_API, endpoint);
+		}
+		pb.environment().put(ENV_SNYK_TOKEN, Preferences.getAuthToken());
 		pb.environment().put("PATH", path.map(p -> p+":"+DEFAULT_MAC_PATH).orElse(DEFAULT_MAC_PATH) + File.pathSeparator + System.getenv("PATH"));
 		return pb;
 	}
@@ -67,6 +81,11 @@ public class ProcessRunner {
 	public ProcessBuilder createWinProcessBuilder(String command, Optional<String> path) {
 		if (command.startsWith("\"/")) command = command.replaceFirst("/", "");
 		ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c ", command);
+		String endpoint = Preferences.getEndpoint();
+		if (endpoint != null && !endpoint.isEmpty()) {
+			pb.environment().put(ENV_SNYK_API,endpoint);
+		}
+		pb.environment().put(ENV_SNYK_TOKEN, Preferences.getAuthToken());
 		pb.environment().put("PATH", path.map(p -> p+";"+DEFAULT_WIN_PATH).orElse(DEFAULT_WIN_PATH) + File.pathSeparator + System.getenv("PATH"));
 
 		// debug logging on windows machines
@@ -80,6 +99,4 @@ public class ProcessRunner {
 
 		return pb;
 	}
-
-
 }

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
@@ -33,27 +33,27 @@ public class SnykCliRunner {
 	
 	private static final String MONITOR_PARAM = "monitor --json";
 
-	private static final String AUTH_PARAM = "auth";
+//	private static final String AUTH_PARAM = "auth";
 	private static final String CONFIG_PARAM = "config";
 	private static final String IGNORE_PARAM = "ignore";
 	
 	ProcessRunner processRunner = new ProcessRunner();
 	
-	public ProcessResult snykAuth() {
-		String authToken = Preferences.getAuthToken();
-		if (authToken == null || authToken.isEmpty()) {
-			try {
-				String apiToken = Authenticator.INSTANCE.callLogin();
-				Preferences.store(Preferences.AUTH_TOKEN_KEY, apiToken);
-				authToken = Preferences.getAuthToken();
-			} catch (AuthException e) {
-				e.printStackTrace();
-				return ProcessResult.error(e.getMessage());
-				
-			}
-		}
-		return snykRun(Lists.of​(AUTH_PARAM, authToken));
-	}
+//	public ProcessResult snykAuth() {
+//		String authToken = Preferences.getAuthToken();
+//		if (authToken == null || authToken.isEmpty()) {
+//			try {
+//				String apiToken = Authenticator.INSTANCE.callLogin();
+//				Preferences.store(Preferences.AUTH_TOKEN_KEY, apiToken);
+//				authToken = Preferences.getAuthToken();
+//			} catch (AuthException e) {
+//				e.printStackTrace();
+//				return ProcessResult.error(e.getMessage());
+//
+//			}
+//		}
+//		return snykRun(Lists.of​(AUTH_PARAM, authToken));
+//	}
 	
 	public ProcessResult snykConfig() {
 		return snykRun(Lists.of​(CONFIG_PARAM));

--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/views/DataProvider.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/views/DataProvider.java
@@ -107,11 +107,12 @@ public class DataProvider {
 		abort.set(false);
 
 
-		try {
-			Authenticator.INSTANCE.doAuthentication();
-		} catch (AuthException e) {
-			return Lists.of​(error("", e));
-		}
+		// we don't need to do authentication hier because of passing SNYK_TOKEN
+//		try {
+//			Authenticator.INSTANCE.doAuthentication();
+//		} catch (AuthException e) {
+//			return Lists.of​(error("", e));
+//		}
 			
 		List<DisplayModel> result = new ArrayList<>();
 		for (IProject project : projects) {


### PR DESCRIPTION
This PR fixes issue with running 'auth' command if token was already provided.
Now we use Eclipse preferences only, so snyk CLI runs can use different settings (~/.config/configstore/snyk.json).