### PR TITLE
fix: quote full path to executable and params

### DIFF
--- a/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
+++ b/snyk_eclipse_plugin/src/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
@@ -113,7 +113,8 @@ public class SnykCliRunner {
 		
 		if (SystemUtils.IS_OS_MAC) {
 			runnable = getRunnableLocation(SNYK_CLI_MAC);
-			processbuilder= processRunner.createMacProcessBuilder(runnable + " " + paramsString, path);
+			String quotedParamsString = Arrays.stream(paramsString.split(" ")).collect(Collectors.joining("\" \"", "\"", "\""));
+			processbuilder= processRunner.createMacProcessBuilder("\"" + runnable + "\" " + quotedParamsString, path);
 		} else if (SystemUtils.IS_OS_LINUX) {
 			runnable = getRunnableLocation(SNYK_CLI_LINUX);
 			processbuilder= processRunner.createLinuxProcessBuilder(runnable + " " + paramsString, path);


### PR DESCRIPTION
Eclipse installed via Homebrew has a whitespace in the path (`Eclipse Platform.app`), so we have to quote executable path and params as well.