### PR TITLE
fix: don't set permissions for windows binary

### DIFF
--- a/io.snyk.bin.win/build.properties
+++ b/io.snyk.bin.win/build.properties
@@ -2,5 +2,4 @@ bin.includes = feature.xml,\
                snyk-win.exe
                           
 root=file:snyk-win.exe
-root.permissions.777=snyk-win.exe
 


### PR DESCRIPTION
This PR fixes exception when Eclipse is installed under `Program Files` on Windows.