### PR TITLE
docs(license): add apache 2.0 license documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 Snyk Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
By referencing the [Snyk Intellij plugin](https://github.com/snyk/snyk-intellij-plugin), it is licensed under Apache 2.0 and is easy for developers to quickly see.

This Eclipse plugin, did not have a License file attached to this repo, so it wasn't as clear. It wasn't until I had to view https://marketplace.eclipse.org/content/snyk-vuln-scanner, to see that the License is Apache 2.0. That was a little bit harder to find, so I'm proposing adding this License file to the repository.

Also, under `io.snyk.feature.feature.xml` there is a reference to the Apache 2.0 License with the copyright year as 2019, hence why I put that date in this PR instead of 2021.