### PR TITLE
fix: add additional arch mapping for LS download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Snyk Changelog
 
 ## [2.0.0] - Unreleased
+### Fixes
+- support download of Language Server for Apple M1
+
+## [2.0.0] - v20220517.090738
 
 ### Changes
 

--- a/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
@@ -37,6 +37,7 @@ public class LsRuntimeEnvironment {
     map.put("x64", "amd64");
 
     map.put("aarch_64", "arm64");
+    map.put("aarch64", "arm64");
     map.put("arm64", "arm64");
 
     map.put("arm_32", "arm");


### PR DESCRIPTION
### Description

macOS M1 reports an unexpected architecture (aarch64) which is not covered by the current arch to language server mapping. This PR fixes this.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
