### PR TITLE
fix: use unmodifiable collection for iterating over list of language …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [2.0.0] - Unreleased
 
+### Fixes
+- fixed ConcurrentModificationException when submitting configuration to language server
+
+## [2.0.0] - v20220610.102110
+
 
 ### Fixes
 - fixed legacy Snyk View scan under Windows

--- a/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
@@ -2,6 +2,9 @@ package io.snyk.languageserver;
 
 import io.snyk.eclipse.plugin.properties.Preferences;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
+
+import java.util.Collections;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.lsp4e.LanguageServersRegistry;
@@ -25,7 +28,7 @@ public class LsConfigurationUpdater {
     for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
       if (project.isAccessible()) {
         try {
-          var servers = LanguageServiceAccessor.getLanguageServers(project, null);
+          var servers = Collections.unmodifiableCollection(LanguageServiceAccessor.getLanguageServers(project, null));
           for (LanguageServer ls : servers) {
             var currentDefinition = LanguageServiceAccessor.resolveServerDefinition(ls);
             if (currentDefinition.isEmpty() || !currentDefinition.get().id.equals(definition.id)) continue;


### PR DESCRIPTION
…servers

### Description

Avoid concurrent modification exception by using unmmodifiable collection when iterating over language server list to submit configuration changes.

### Checklist

- [x] Linted
- [x] CHANGELOG.md updated

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
