### PR TITLE
fix: various fixes & improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Fixes
 - fixed ConcurrentModificationException when submitting configuration to language server
 - don't shutdown Language Server when all associated files are closed, in order to preserve cached diagnostics for an hour
-- mark retrieved diagnostics as `Snyk` instead of `Language Server`
+
+### Changes
+- mark retrieved diagnostics as `Snyk` instead of `Language Server` to be able to filter, group and sort in problem view.
 
 ## [2.0.0] - v20220610.102110
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 - fixed ConcurrentModificationException when submitting configuration to language server
+- don't shutdown Language Server when all associated files are closed, in order to preserve cached diagnostics for an hour
+- mark retrieved diagnostics as `Snyk` instead of `Language Server`
 
 ## [2.0.0] - v20220610.102110
 

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -148,6 +148,7 @@
       id="io.snyk.languageserver"
       label="Snyk Language Server"
       clientImpl="io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient"
+      stopOnLastDisconnectedDocument="3600"
       singleton="true">
     </server>
 

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -149,7 +149,8 @@
       label="Snyk Language Server"
       clientImpl="io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient"
       stopOnLastDisconnectedDocument="3600"
-      singleton="true">
+      singleton="true"
+      makerType="io.snyk.languageserver.marker">
     </server>
 
     <!-- snyk code -->
@@ -223,5 +224,14 @@
       contentType="org.python.pydev.pythonfile"
       id="io.snyk.languageserver">
     </contentTypeMapping>
+  </extension>
+  <extension
+        id="io.snyk.languageserver.marker"
+        name="Snyk"
+        point="org.eclipse.core.resources.markers">
+    <super
+          type="org.eclipse.lsp4e.diagnostic">
+    </super>
+    <persistent value="false"/>
   </extension>
 </plugin>

--- a/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
@@ -67,7 +67,6 @@ public class LsConfigurationUpdater {
       organization);
   }
 
-  @SuppressWarnings("unused") // getters for GSon serialization
   static class Settings {
     private final String activateSnykOpenSource;
     private final String activateSnykCode;


### PR DESCRIPTION
### Description

- don't shutdown LS when all associated files are closed, in order to preserve cached diagnostics for an hour
- mark retrieved diagnostics as `Snyk` instead of `Language Server`

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
