### PR TITLE
fix: Parse and Display multi-module project findings in legacy view correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [2.0.0] - Unreleased
 
 ### Fixes
+- parse and display findings of multi-module projects in Snyk View, supporting the `--all-projects` parameter there as well.
+
+
+## [2.0.0] - v20220620.201253
+
+### Fixes
 - fixed ConcurrentModificationException when submitting configuration to language server
 - don't shutdown Language Server when all associated files are closed, in order to preserve cached diagnostics for an hour
 
@@ -10,7 +16,6 @@
 - mark retrieved diagnostics as `Snyk` instead of `Language Server` to be able to filter, group and sort in problem view.
 
 ## [2.0.0] - v20220610.102110
-
 
 ### Fixes
 - fixed legacy Snyk View scan under Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 - parse and display findings of multi-module projects in Snyk View, supporting the `--all-projects` parameter there as well.
+- use preferences to configure additional environment variables in environment of CLI
+- proxy configuration for https proxy is now using `https_proxy=http://configured-proxy-settings-in-eclipse` instead of `https_proxy=https://configured-proxy-settings-in-eclipse`
+- support additional environment variables of the format `a=b=c`, e.g. needed for `MAVEN_OPTS=-Djava.awt.headless=true`
 
 
 ## [2.0.0] - v20220620.201253

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -39,8 +39,11 @@ public class SnykStartup implements IStartup {
   private static boolean downloading = true;
   private ILog logger;
 
+  private static SnykStartup instance;
+
   @Override
   public void earlyStartup() {
+    instance = this;
     if (logger == null) {
        logger = Platform.getLog(getClass());
     }
@@ -77,8 +80,8 @@ public class SnykStartup implements IStartup {
     downloadCLIJob.schedule();
   }
 
-  private SnykView getSnykView() {
-    if (snykView == null) {
+  public static SnykView getSnykView() {
+    if (instance.snykView == null) {
       IWorkbench workbench = PlatformUI.getWorkbench();
 
       workbench.getDisplay().syncExec(() -> {
@@ -86,7 +89,7 @@ public class SnykStartup implements IStartup {
 
         if (workbenchWindow != null) {
           try {
-            snykView = (SnykView) workbenchWindow.getActivePage().showView(SnykView.ID);
+            instance.snykView = SnykView.getInstance();
           } catch (PartInitException partInitException) {
             logError(partInitException);
           }
@@ -94,7 +97,7 @@ public class SnykStartup implements IStartup {
       });
     }
 
-    return snykView;
+    return instance.snykView;
   }
 
   private boolean downloadLS() {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -169,4 +169,8 @@ public class SnykStartup implements IStartup {
   public void setLogger(ILog logger) {
     this.logger = logger;
   }
+
+  public LsRuntimeEnvironment getRuntimeEnvironment() {
+    return runtimeEnvironment;
+  }
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/domain/ScanResult.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/domain/ScanResult.java
@@ -13,6 +13,11 @@ public class ScanResult {
   String summary;
   Integer uniqueCount;
   String path;
+  String displayTargetFile;
+
+  public String getDisplayTargetFile() {
+    return displayTargetFile;
+  }
 
   public ScanResult() {
   }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
@@ -18,7 +18,6 @@ import java.io.File;
 public class PreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
   private static final Preferences PREFERENCES = new Preferences();
-  private TokenFieldEditor tokenField;
 
   public PreferencesPage() {
     super(GRID);
@@ -33,9 +32,9 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
   @Override
   protected void createFieldEditors() {
     File lsFile = new LsRuntimeEnvironment(PREFERENCES).getLSFile();
-    String msg = "Snyk LS not found at " + lsFile.getAbsolutePath();
+    String msg = "Snyk Language Server not found at " + lsFile.getAbsolutePath();
     if (lsFile.exists()) {
-      msg = "Snyk LS found: " + lsFile.getAbsolutePath();
+      msg = "Snyk Language Server found: " + lsFile.getAbsolutePath();
     }
     addField(new LabelFieldEditor(msg, getFieldEditorParent()));
 
@@ -48,7 +47,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 
     addField(space());
 
-    tokenField = new TokenFieldEditor(PREFERENCES, Preferences.AUTH_TOKEN_KEY, "Snyk API Token:",
+    TokenFieldEditor tokenField = new TokenFieldEditor(PREFERENCES, Preferences.AUTH_TOKEN_KEY, "Snyk API Token:",
       getFieldEditorParent());
     addField(tokenField);
     addField(new StringFieldEditor(Preferences.PATH_KEY, "Path:", getFieldEditorParent()));
@@ -90,9 +89,6 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
     boolean superOK = super.performOk();
     var snykView = SnykStartup.getSnykView();
     snykView.disableRunAbortActions();
-    if (tokenField.getStringValue() == null || tokenField.getStringValue().isEmpty()) {
-      DataProvider.popUpWarn("Authentication", "Please add a valid Snyk Token, else scanning is not possible.");
-    }
     snykView.toggleRunActionEnablement();
     new LsConfigurationUpdater().configurationChanged(PREFERENCES);
     return superOK;

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
@@ -1,10 +1,8 @@
 package io.snyk.eclipse.plugin.properties;
 
-import io.snyk.eclipse.plugin.Activator;
-import io.snyk.eclipse.plugin.runner.SnykCliRunner;
+import io.snyk.eclipse.plugin.SnykStartup;
 import io.snyk.eclipse.plugin.utils.FileSystemUtil;
 import io.snyk.eclipse.plugin.views.DataProvider;
-import io.snyk.eclipse.plugin.views.SnykView;
 import io.snyk.languageserver.LsConfigurationUpdater;
 import io.snyk.languageserver.LsRuntimeEnvironment;
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -12,10 +10,8 @@ import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
-import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.eclipse.ui.PlatformUI;
 
 import java.io.File;
 
@@ -92,8 +88,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
   @Override
   public boolean performOk() {
     boolean superOK = super.performOk();
-    SnykView snykView = (SnykView) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
-      .findView(SnykView.ID);
+    var snykView = SnykStartup.getSnykView();
     snykView.disableRunAbortActions();
     if (tokenField.getStringValue() == null || tokenField.getStringValue().isEmpty()) {
       DataProvider.popUpWarn("Authentication", "Please add a valid Snyk Token, else scanning is not possible.");

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
@@ -108,6 +108,14 @@ public class ProcessRunner {
       pb.environment().put(Preferences.ORGANIZATION_KEY, organization);
       pb.command().add("--org=" + organization);
     }
+    
+    String additionalParameters = preferences.getPref(Preferences.ADDITIONAL_PARAMETERS);
+    if (additionalParameters != null && !additionalParameters.isBlank()) {
+      var split = additionalParameters.split(" ");
+      for (String param : split) {
+        pb.command().add(param);
+      }
+    }
 
     String token = preferences.getAuthToken();
     if (token != null)

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.snyk.languageserver.LsRuntimeEnvironment;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -29,9 +30,6 @@ public class ProcessRunner {
 
   private static final String ENV_SNYK_API = "SNYK_API";
   private static final String ENV_SNYK_TOKEN = "SNYK_TOKEN";
-  private static final String ENV_SNYK_INTEGRATION_NAME = "SNYK_INTEGRATION_NAME";
-  private static final String ENV_SNYK_INTEGRATION_VERSION = "SNYK_INTEGRATION_VERSION";
-
   private static final String HOME = System.getProperty("user.home");
   private static final String DEFAULT_MAC_PATH = "/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin:" + HOME + "/bin:"
     + HOME + "/.cargo/bin:" + System.getenv("GOPATH") + "/bin" + System.getenv("GOROOT") + "/bin";
@@ -89,6 +87,7 @@ public class ProcessRunner {
 
     ProcessBuilder pb = new ProcessBuilder(cmd);
     setupProcessBuilderBase(pb);
+    // TODO: move to runtimeEnvironment
     if (path.isPresent() && !path.get().isBlank()) {
       pb.environment().put("PATH",
         path.map(p -> p + File.pathSeparator + defaultPathForOS).orElse(defaultPathForOS)
@@ -98,6 +97,13 @@ public class ProcessRunner {
   }
 
   private void setupProcessBuilderBase(ProcessBuilder pb) {
+    LsRuntimeEnvironment runtimeEnvironment = new LsRuntimeEnvironment(preferences);
+
+    runtimeEnvironment.addPath(pb.environment());
+    runtimeEnvironment.addProxyToEnv(pb.environment());
+    runtimeEnvironment.addAdditionalParamsAndEnv(pb.environment());
+    runtimeEnvironment.addIntegrationInfoToEnv(pb.environment());
+
     String endpoint = preferences.getEndpoint();
     if (endpoint != null && !endpoint.isEmpty()) {
       pb.environment().put(ENV_SNYK_API, endpoint);
@@ -108,7 +114,7 @@ public class ProcessRunner {
       pb.environment().put(Preferences.ORGANIZATION_KEY, organization);
       pb.command().add("--org=" + organization);
     }
-    
+
     String additionalParameters = preferences.getPref(Preferences.ADDITIONAL_PARAMETERS);
     if (additionalParameters != null && !additionalParameters.isBlank()) {
       var split = additionalParameters.split(" ");
@@ -131,9 +137,6 @@ public class ProcessRunner {
     } else {
       pb.environment().put(Preferences.ENABLE_TELEMETRY, "1"); // default to disable telemetry
     }
-
-    pb.environment().put(ENV_SNYK_INTEGRATION_NAME, "ECLIPSE");
-    pb.environment().put(ENV_SNYK_INTEGRATION_VERSION, getVersion());
   }
 
   public ProcessBuilder createMacProcessBuilder(List<String> params, Optional<String> path) {
@@ -153,12 +156,12 @@ public class ProcessRunner {
       + File.pathSeparator + System.getenv("PATH"));
 
     // debug logging on windows machines
-    IStatus[] statuses = new IStatus[]{
-      new Status(Status.INFO, bundle.getSymbolicName(), "env.PATH = " + pb.environment().get("PATH")),
-      new Status(Status.INFO, bundle.getSymbolicName(), "path = " + path),
-      new Status(Status.INFO, bundle.getSymbolicName(), "params = " + params),};
+    IStatus[] statuses = new IStatus[] {
+        new Status(Status.INFO, bundle.getSymbolicName(), "env.PATH = " + pb.environment().get("PATH")),
+        new Status(Status.INFO, bundle.getSymbolicName(), "path = " + path),
+        new Status(Status.INFO, bundle.getSymbolicName(), "params = " + params), };
     MultiStatus multiStatusCommand = new MultiStatus(bundle.getSymbolicName(), Status.INFO, statuses,
-      "Snyk params execution", null);
+        "Snyk params execution", null);
     log.log(multiStatusCommand);
 
     return pb;

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/MenuHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/MenuHandler.java
@@ -1,6 +1,6 @@
 package io.snyk.eclipse.plugin.views;
 
-import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.eclipse.plugin.SnykStartup;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -9,8 +9,6 @@ import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionService;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 
@@ -37,12 +35,9 @@ public class MenuHandler extends AbstractHandler {
   }
 
   private void runForProject(String projectName) {
-    try {
-      SnykView snykView = (SnykView) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(SnykView.ID);
+    SnykView snykView = SnykStartup.getSnykView();
+    if (snykView != null) {
       snykView.testProject(projectName);
-    } catch (PartInitException e) {
-      SnykLogger.logError(e);
     }
   }
-
 }

--- a/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
@@ -10,11 +10,16 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import static io.snyk.eclipse.plugin.utils.FileSystemUtil.getCliDirectory;
+import static org.eclipse.core.net.proxy.IProxyData.HTTPS_PROXY_TYPE;
+import static org.eclipse.core.net.proxy.IProxyData.HTTP_PROXY_TYPE;
 
 public class LsRuntimeEnvironment {
   private final Preferences preferences;
@@ -116,7 +121,8 @@ public class LsRuntimeEnvironment {
       env.put(Preferences.ORGANIZATION_KEY, pref);
     }
   }
-  void addAdditionalParamsAndEnv(Map<String, String> env) {
+
+  public void addAdditionalParamsAndEnv(Map<String, String> env) {
     String additionalParams = preferences.getPref(Preferences.ADDITIONAL_PARAMETERS, "");
     if (additionalParams != null && !additionalParams.isBlank()) {
       env.put(Preferences.ADDITIONAL_PARAMETERS, additionalParams);
@@ -130,8 +136,11 @@ public class LsRuntimeEnvironment {
       var variables = additionalEnv.split(";");
       for (String variable : variables) {
         var split = variable.split("=");
-        if (split.length == 2) {
-          env.put(split[0], split[1]);
+        if (split.length > 1) {
+          String name = split[0];
+          List<String> value = new ArrayList<>(Arrays.asList(split));
+          value.remove(0);
+          env.put(name, String.join("=", value)); // allow equal signs in variable values
         }
       }
     }
@@ -143,7 +152,7 @@ public class LsRuntimeEnvironment {
     env.put(Preferences.ACTIVATE_SNYK_OPEN_SOURCE, preferences.getPref(Preferences.ACTIVATE_SNYK_OPEN_SOURCE));
   }
 
-  private void addPath(Map<String, String> env) {
+  public void addPath(Map<String, String> env) {
     var pathOptional = preferences.getPath();
     if (pathOptional.isPresent()) {
       var path = pathOptional.get();
@@ -160,7 +169,7 @@ public class LsRuntimeEnvironment {
     }
   }
 
-  private void addProxyToEnv(Map<String, String> env) {
+  public void addProxyToEnv(Map<String, String> env) {
     for (Entry<Object, Object> entry : System.getProperties().entrySet()) {
       if (!(entry.getKey() instanceof String && entry.getValue() instanceof String)) continue;
 
@@ -184,8 +193,14 @@ public class LsRuntimeEnvironment {
         }
         creds += "@";
       }
+      // TODO urlencode creds
       String value = creds + data.getHost() + ":" + data.getPort();
-      env.put(data.getType().toLowerCase() + "_proxy", value);
+      String protocol = data.getType();
+      if (data.getType().equals(HTTPS_PROXY_TYPE)) {
+        // TODO verify correctness of this!
+        protocol = HTTP_PROXY_TYPE;
+      }
+      env.put(protocol + "_proxy", value);
     }
     String[] nonProxiedHostsArray = service.getNonProxiedHosts();
     if (nonProxiedHostsArray != null && nonProxiedHostsArray.length > 0) {
@@ -205,7 +220,7 @@ public class LsRuntimeEnvironment {
     return bundleContext.getService(serviceRef);
   }
 
-  private void addIntegrationInfoToEnv(Map<String, String> env) {
+  public void addIntegrationInfoToEnv(Map<String, String> env) {
     env.put("SNYK_INTEGRATION_NAME", Activator.INTEGRATION_NAME);
     env.put("SNYK_INTEGRATION_VERSION", Activator.PLUGIN_VERSION);
   }

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -1,7 +1,7 @@
 package io.snyk.languageserver.protocolextension;
 
+import io.snyk.eclipse.plugin.SnykStartup;
 import io.snyk.eclipse.plugin.properties.Preferences;
-import io.snyk.eclipse.plugin.views.SnykView;
 import io.snyk.languageserver.protocolextension.messageObjects.HasAuthenticatedParam;
 import org.eclipse.lsp4e.LanguageClientImpl;
 import org.eclipse.lsp4e.ServerMessageHandler;
@@ -50,8 +50,8 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 
   private void enableSnykViewRunActions() {
     PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
-      var snykView = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().findView(SnykView.ID);
-      if (snykView != null) ((SnykView) snykView).toggleRunActionEnablement();
+      var snykView = SnykStartup.getSnykView();
+      if (snykView != null) snykView.toggleRunActionEnablement();
     });
   }
 

--- a/tests/src/test/java/io/snyk/languageserver/LsRuntimeEnvironmentTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsRuntimeEnvironmentTest.java
@@ -110,13 +110,14 @@ class LsRuntimeEnvironmentTest extends LsBaseTest {
   void testAddAdditionalParamsAndEnvAddsThemToEnvironment() throws StorageException {
     HashMap<String, String> env = new HashMap<>();
     when(preferenceMock.getPref(Preferences.ADDITIONAL_PARAMETERS, "")).thenReturn("addParams");
-    when(preferenceMock.getPref(Preferences.ADDITIONAL_ENVIRONMENT, "")).thenReturn("a=b;c=d");
+    when(preferenceMock.getPref(Preferences.ADDITIONAL_ENVIRONMENT, "")).thenReturn("a=b;c=d;e=f=g");
 
     environment.addAdditionalParamsAndEnv(env);
 
     assertEquals("addParams", env.get(Preferences.ADDITIONAL_PARAMETERS));
     assertEquals("b", env.get("a"));
     assertEquals("d", env.get("c"));
+    assertEquals("f=g", env.get("e"));
   }
 
   @Test


### PR DESCRIPTION
### Description

Previously, multi-module projects were not supported, there was rudimentary support for maven. Now both parsing and displaying is working, if CLI reports a multi-module scenario.

Also, if the plugin finds more than one pom file, as before, it automatically does a multi-pom scan by automatically setting `--all-projects` for that scan.

### Checklist

- [x] Linted
- [x] Changelog updated

### Screenshots / GIFs

![image](https://user-images.githubusercontent.com/20150761/174776280-4fde9f27-7881-4905-a377-84af8c672b6b.png)

