### PR TITLE
fix: proxy support

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -7,6 +7,7 @@ import io.snyk.eclipse.plugin.views.SnykView;
 import io.snyk.languageserver.LsRuntimeEnvironment;
 import io.snyk.languageserver.download.LsDownloadRequest;
 import io.snyk.languageserver.download.LsDownloader;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.runtime.ILog;
@@ -57,7 +58,7 @@ public class SnykStartup implements IStartup {
             SnykView snykView = getSnykView();
             snykView.disableRunAbortActions();
             cliFile.getParentFile().mkdirs();
-            CliDownloader.newInstance().download(cliFile, monitor);
+            CliDownloader.newInstance(HttpClientBuilder.create()).download(cliFile, monitor);
             cliFile.setExecutable(true);
             snykView.toggleRunActionEnablement();
           }
@@ -168,9 +169,5 @@ public class SnykStartup implements IStartup {
 
   public void setLogger(ILog logger) {
     this.logger = logger;
-  }
-
-  public LsRuntimeEnvironment getRuntimeEnvironment() {
-    return runtimeEnvironment;
   }
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/CliDownloader.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/CliDownloader.java
@@ -3,32 +3,46 @@ package io.snyk.eclipse.plugin.utils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.snyk.eclipse.plugin.domain.LatestReleaseInfo;
+import io.snyk.eclipse.plugin.properties.Preferences;
+import io.snyk.languageserver.LsRuntimeEnvironment;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 
+// TODO: Remove class in favor of Language Server downloading the CLI
 public class CliDownloader {
 
   private static final String LATEST_RELEASES_URL = "https://api.github.com/repos/snyk/snyk/releases/latest";
   private static final String LATEST_RELEASE_DOWNLOAD_URL = "https://github.com/snyk/snyk/releases/download/%s/%s";
+  private final CloseableHttpClient httpClient;
 
-  public static CliDownloader newInstance() {
-    return new CliDownloader();
+  public CliDownloader(HttpClientBuilder httpClientBuilder) {
+    LsRuntimeEnvironment runtimeEnvironment = new LsRuntimeEnvironment(new Preferences());
+    configure(httpClientBuilder, runtimeEnvironment.getProxyService().getProxyData(IProxyData.HTTPS_PROXY_TYPE));
+    httpClient = httpClientBuilder.build();
+  }
+
+  public static CliDownloader newInstance(HttpClientBuilder httpClientBuilder) {
+    return new CliDownloader(httpClientBuilder);
   }
 
   public File download(File destinationFile, IProgressMonitor monitor) {
-    CloseableHttpClient httpClient = HttpClients
-      .custom()
-      .setRedirectStrategy(new LaxRedirectStrategy())
-      .build();
-
     try {
       String snykWrapperFileName = Platform.current().snykWrapperFileName;
       String cliVersion = Objects.requireNonNull(getLatestReleaseInfo()).getTagName();
@@ -62,6 +76,31 @@ public class CliDownloader {
   }
 
   private String requestLatestReleaseInfo() throws IOException {
-    return HttpClients.createDefault().execute(new HttpGet(LATEST_RELEASES_URL), new BasicResponseHandler());
+    return httpClient.execute(new HttpGet(LATEST_RELEASES_URL), new BasicResponseHandler());
+  }
+
+  @SuppressWarnings("DuplicatedCode") // this whole class will go away, once we switch to language server completely
+  private void configure(HttpClientBuilder builder, IProxyData data) {
+    if (data == null) return;
+
+    HttpHost proxy = new HttpHost(data.getHost(), data.getPort());
+    var proxyRoutePlanner = new DefaultProxyRoutePlanner(proxy);
+    builder.setRoutePlanner(proxyRoutePlanner);
+
+    if (data.getUserId() == null) return;
+
+    var credentialsProvider = new BasicCredentialsProvider();
+    var authScope = new AuthScope(proxy);
+    var credentials = new UsernamePasswordCredentials(data.getUserId(), data.getPassword());
+    credentialsProvider.setCredentials(authScope, credentials);
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+
+    AuthCache authCache = new BasicAuthCache();
+    BasicScheme basicAuth = new BasicScheme();
+    authCache.put(proxy, basicAuth);
+
+    var context = HttpClientContext.create();
+    context.setCredentialsProvider(credentialsProvider);
+    context.setAuthCache(authCache);
   }
 }

--- a/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
@@ -193,14 +193,14 @@ public class LsRuntimeEnvironment {
         }
         creds += "@";
       }
-      // TODO urlencode creds
-      String value = creds + data.getHost() + ":" + data.getPort();
-      String protocol = data.getType();
+      String protocol = data.getType().toLowerCase();
       if (data.getType().equals(HTTPS_PROXY_TYPE)) {
         // TODO verify correctness of this!
-        protocol = HTTP_PROXY_TYPE;
+        protocol = HTTP_PROXY_TYPE.toLowerCase();
       }
-      env.put(protocol + "_proxy", value);
+      // TODO urlencode creds
+      String value = creds + protocol + "://" + data.getHost() + ":" + data.getPort();
+      env.put(data.getType().toLowerCase() + "_proxy", value);
     }
     String[] nonProxiedHostsArray = service.getNonProxiedHosts();
     if (nonProxiedHostsArray != null && nonProxiedHostsArray.length > 0) {

--- a/plugin/src/main/java/io/snyk/languageserver/download/LsDownloader.java
+++ b/plugin/src/main/java/io/snyk/languageserver/download/LsDownloader.java
@@ -57,7 +57,7 @@ public class LsDownloader {
     }
   }
 
-  private void configure(HttpClientBuilder builder, IProxyData data) {
+  public void configure(HttpClientBuilder builder, IProxyData data) {
     if (data == null) return;
 
     HttpHost proxy = new HttpHost(data.getHost(), data.getPort());


### PR DESCRIPTION
### Description

- use proxy configuration from language server download in cli download
- correct environment population with proxy data

The CLI download in Eclipse should be removed in favor of relying on the CLI download from language server. For this to happen, we need to unify directories in a follow-up PR.

![image](https://user-images.githubusercontent.com/20150761/175771456-66577aaf-abf1-4013-8fbc-79c69bd65f9f.png)
![image](https://user-images.githubusercontent.com/20150761/175771491-e5170bc2-fd93-4770-bf76-2d54827b0937.png)
![image](https://user-images.githubusercontent.com/20150761/175771463-364381d4-30de-4bc7-b38d-518339678988.png)
