### PR TITLE
fix: also allow CLI download, if no http proxy is configured (fixes #57)

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/CliDownloader.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/CliDownloader.java
@@ -81,7 +81,7 @@ public class CliDownloader {
 
   @SuppressWarnings("DuplicatedCode") // this whole class will go away, once we switch to language server completely
   private void configure(HttpClientBuilder builder, IProxyData data) {
-    if (data == null) return;
+    if (data == null || data.getHost() == null) return;
 
     HttpHost proxy = new HttpHost(data.getHost(), data.getPort());
     var proxyRoutePlanner = new DefaultProxyRoutePlanner(proxy);


### PR DESCRIPTION
### Description

If no proxy settings were configured, the plugin did not download the CLI. This PR should fix it.

Fixes Issue #57 
