### PR TITLE
feat: add support for `window/showDocument` request [ROAD-1012]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.0.0] - Unreleased
 ### Changes
+- feat: add support for `window/showDocument` request
+
+## [2.0.0] - v20220725.070608
+### Changes
 - refactor LSP extensions to use snyk namespace - this will force an LS Server update
 - configure LS with initialize options instead of env vars
 - remove redundant CLI download

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/preferences/Preferences.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/preferences/Preferences.java
@@ -80,15 +80,15 @@ public class Preferences {
     }
 
     String token = SystemUtils.getEnvironmentVariable(EnvironmentConstants.ENV_SNYK_TOKEN, "");
-    if (getPref(AUTH_TOKEN_KEY) == null && token != "") {
+    if (getPref(AUTH_TOKEN_KEY) == null && !"".equals(token)) {
       store(AUTH_TOKEN_KEY, token);
     }
     String endpoint = SystemUtils.getEnvironmentVariable(EnvironmentConstants.ENV_SNYK_API, "");
-    if (getPref(ENDPOINT_KEY) == null && endpoint != "") {
+    if (getPref(ENDPOINT_KEY) == null && !"".equals(endpoint)) {
       store(ENDPOINT_KEY, endpoint);
     }
     String org = SystemUtils.getEnvironmentVariable(EnvironmentConstants.ENV_SNYK_ORG, "");
-    if (getPref(ORGANIZATION_KEY) == null && org != "") {
+    if (getPref(ORGANIZATION_KEY) == null && !"".equals(org)) {
       store(ORGANIZATION_KEY, org);
     }
   }

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -71,6 +71,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
     ServerMessageHandler.showMessage("Authentication with Snyk successful", messageParams);
   }
 
+  // TODO: remove once LSP4e supports `showDocument` in its next release (it's been merged to it already)
   @Override
   public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
     return CompletableFuture.supplyAsync(() -> {

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -73,17 +73,16 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 
   @Override
   public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
-    PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
-      var window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-      if (window != null) {
-        var page = window.getActivePage();
+    return CompletableFuture.supplyAsync(() -> {
+      PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
         var location = new Location(params.getUri(), params.getSelection());
-        if (page != null) {
+        var window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window != null) {
+          var page = window.getActivePage();
           LSPEclipseUtils.openInEditor(location, page);
         }
-      }
+      });
+      return new ShowDocumentResult(true);
     });
-    return CompletableFuture.completedFuture(null);
   }
-
 }

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -1,19 +1,24 @@
 package io.snyk.languageserver.protocolextension;
 
-import io.snyk.eclipse.plugin.SnykStartup;
-import io.snyk.eclipse.plugin.properties.preferences.Preferences;
-import io.snyk.languageserver.protocolextension.messageObjects.HasAuthenticatedParam;
-import io.snyk.languageserver.protocolextension.messageObjects.SnykIsAvailableCliParams;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageClientImpl;
 import org.eclipse.lsp4e.ServerMessageHandler;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.ShowDocumentParams;
+import org.eclipse.lsp4j.ShowDocumentResult;
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.ui.PlatformUI;
 
-import java.util.concurrent.CompletableFuture;
+import io.snyk.eclipse.plugin.SnykStartup;
+import io.snyk.eclipse.plugin.properties.preferences.Preferences;
+import io.snyk.languageserver.protocolextension.messageObjects.HasAuthenticatedParam;
+import io.snyk.languageserver.protocolextension.messageObjects.SnykIsAvailableCliParams;
 
 @SuppressWarnings("restriction")
 public class SnykExtendedLanguageClient extends LanguageClientImpl {
@@ -54,7 +59,8 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
   private void enableSnykViewRunActions() {
     PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
       var snykView = SnykStartup.getSnykView();
-      if (snykView != null) snykView.toggleRunActionEnablement();
+      if (snykView != null)
+        snykView.toggleRunActionEnablement();
     });
   }
 
@@ -64,4 +70,20 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
     messageParams.setMessage("The authentication token has been stored in Snyk Preferences.");
     ServerMessageHandler.showMessage("Authentication with Snyk successful", messageParams);
   }
+
+  @Override
+  public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
+    PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+      var window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+      if (window != null) {
+        var page = window.getActivePage();
+        var location = new Location(params.getUri(), params.getSelection());
+        if (page != null) {
+          LSPEclipseUtils.openInEditor(location, page);
+        }
+      }
+    });
+    return CompletableFuture.completedFuture(null);
+  }
+
 }


### PR DESCRIPTION
### Description

To provide server controlled navigation, the `window/showDocument` message is needed. This PR adds support for it by implementing it. Next step is a PR to LSP4e to add it to the base plugin.

### Checklist

- [x] Linted
- [x] CHANGELOG.md updated

### Screenshots / GIFs
Navigation via code lenses possible through this PR.
![image](https://user-images.githubusercontent.com/20150761/181365252-ec5d8218-a7cc-4220-93b9-fc5b81ccb70c.png)
