### PR TITLE
feat: add support for insecure CAs in HTTP calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.0.0] - Unreleased
 ### Changes
+- add support for insecure and custom CAs to download and API checks
+
+## [2.0.0] - v20220905.164345
+### Changes
 - promote language server from BETA to GA
 - announce workspace folder capability correctly
 - disable / enable Snyk Code based on org settings


### PR DESCRIPTION
### Description

Previously, downloads and API calls from Eclipse didn't work with custom CAs. Now those calls also respect the preference setting.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
