### PR TITLE
fix: pin lsp4e version

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -16,7 +16,7 @@
       </location>
 
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <repository location="https://download.eclipse.org/lsp4e/releases/latest/"/>
+        <repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/"/>
         <unit id="org.eclipse.lsp4e" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.jdt" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>


### PR DESCRIPTION
### Description

Fixes release - https://github.com/snyk/snyk-eclipse-plugin/actions/runs/3583019028/jobs/6028074773. LSP4E has transition to JDK17, which breaks our support.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
