### PR TITLE
chore: update README sync workflow

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/docs/ide-tools/eclipse-plugin/README.md
+          SOURCE_PATH: ./docs/docs/integrations/ide-tools/eclipse-plugin/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: snyk-eclipse-plugin
           DESTINATION_BRANCH: docs/automatic-gitbook-update


### PR DESCRIPTION
### Description

To prepare for planned docs restructuring, where the docs for IDE tools will now be nested under the /integrations/ path, it's necessary to adjust the `readme-sync` workflow to ensure docs are continually synced with the README.

### Checklist

- ~~[ ]  Tests added and all succeed~~ Not applicable
- ~~[ ] Linted~~ Not applicable
- ~~[ ] CHANGELOG.md updated~~ Not applicable
- ~~[ ] README.md updated, if user-facing~~ Not applicable
