### PR TITLE
chore: fix sed bug in readme sync

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -20,7 +20,7 @@ jobs:
 
           cp $SOURCE_PATH ./$DESTINATION_REPOSITORY/$FILE_TO_COMMIT
           sed -i \
-              -e "s|../../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/|g" \
+              -e "s|../../../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/|g" \
               ./$DESTINATION_REPOSITORY/$FILE_TO_COMMIT
           sed -i \
               -E "s|\!\\[([[:alnum:][:space:][:punct:]]*)\]\(<([[:alnum:][:punct:]\-\.\/:[:space:]\(\)]+)>\)|<img src=\"\2\" alt=\"\1\" />|g" \


### PR DESCRIPTION
### Description

A fast follow from #125. Due to an extra level in the folder hierarchy, we need to adjust our sed script slightly.

### Checklist

- ~~[ ]  Tests added and all succeed~~ Not applicable
- ~~[ ] Linted~~ Not applicable
- ~~[ ] CHANGELOG.md updated~~ Not applicable
- ~~[ ] README.md updated, if user-facing~~ Not applicable
