### PR TITLE
chore: unpin LSP4e, release 2.1 [HEAD-170]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,5 @@ jobs:
       uses: 'google-github-actions/upload-cloud-storage@v0'
       with:
         path: "./update-site/target/repository/"
-        destination: "snyk-eclipse-plugin-test/preview"
+        destination: "snyk-eclipse-plugin-test/preview-2.1"
         predefinedAcl: publicRead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'zulu'
         cache: maven
 
     - name: Decode Keystore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v0'
         with:
           path: "./update-site/target/repository/"
-          destination: "snyk-eclipse-plugin/weekly"
+          destination: "snyk-eclipse-plugin/weekly-2.1"
           predefinedAcl: publicRead
 
       - name: Extract release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
           cache: maven
 
@@ -85,6 +85,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./update-site/target/update-site-2.0.0-SNAPSHOT.zip
-          asset_name: "update-site-2.0.0-${{ steps.createTag.outputs.tagName }}.zip"
+          asset_path: ./update-site/target/update-site-2.1.0-SNAPSHOT.zip
+          asset_name: "update-site-2.1.0-${{ steps.createTag.outputs.tagName }}.zip"
           asset_content_type: application/zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Changes
 - Increase LS version
 
+## [2.1.0] - UNRELEASED
+### Changes
+- unpin LSP4e dependency - this requires running Eclipse on JDK 17+
+
 ## [2.0.0] - v20230131.163308
 ### Changes
 - Snyk Test now scans the selected project

--- a/feature/category.xml
+++ b/feature/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_2.0.0.qualifier.jar" id="io.snyk.scanner" version="2.0.0.qualifier">
+  <feature url="features/io.snyk.scanner_2.1.0.qualifier.jar" id="io.snyk.scanner" version="2.1.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security - Code, Open Source, IaC Configurations">

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="io.snyk.scanner"
       label="Snyk Security - Code, Open Source, IaC Configurations"
-      version="2.0.0.qualifier"
+      version="2.1.0.qualifier"
       provider-name="Snyk">
 
    <description url="https://snyk.io">

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.snyk</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>io.snyk.scanner</artifactId>

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -3,15 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: io.snyk.eclipse.plugin;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.1.0.qualifier
 Bundle-Activator: io.snyk.eclipse.plugin.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.core.resources,
- org.eclipse.lsp4e;bundle-version="[0.13.9,0.14.0.qualifier]",
- org.eclipse.lsp4e.jdt;bundle-version="0.10.1",
+ org.eclipse.lsp4e,
+ org.eclipse.lsp4e.jdt,
  org.eclipse.equinox.security,
  org.eclipse.equinox.security.ui,
  org.eclipse.lsp4j,

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: io.snyk.eclipse.plugin;singleton:=true
 Bundle-Version: 2.1.0.qualifier
 Bundle-Activator: io.snyk.eclipse.plugin.Activator

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.snyk</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/PreferencesPage.java
@@ -1,17 +1,7 @@
 package io.snyk.eclipse.plugin.properties;
 
-import io.snyk.eclipse.plugin.SnykStartup;
-import io.snyk.eclipse.plugin.properties.preferences.ApiClient;
-import io.snyk.eclipse.plugin.properties.preferences.Preferences;
-import io.snyk.eclipse.plugin.utils.SnykLogger;
-import io.snyk.languageserver.LsConfigurationUpdater;
-import io.snyk.languageserver.LsRuntimeEnvironment;
-import io.snyk.languageserver.download.HttpClientFactory;
-import io.snyk.languageserver.download.LsBinaries;
-
 import java.io.File;
 
-import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
@@ -20,6 +10,12 @@ import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import io.snyk.eclipse.plugin.SnykStartup;
+import io.snyk.eclipse.plugin.properties.preferences.ApiClient;
+import io.snyk.eclipse.plugin.properties.preferences.Preferences;
+import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.languageserver.LsConfigurationUpdater;
 
 public class PreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 	private BooleanFieldEditor snykCodeCheckbox;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.snyk</groupId>
   <artifactId>parent</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -11,8 +11,8 @@
     <tycho.scmUrl>scm:git:https://github.com/snyk/snyk-eclipse-plugin.git</tycho.scmUrl>
     <target-config>target-platform</target-config>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <modules>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <packaging>eclipse-target-definition</packaging>
 </project>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -16,7 +16,7 @@
       </location>
 
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/"/>
+        <repository location="https://download.eclipse.org/lsp4e/releases/latest/"/>
         <unit id="org.eclipse.lsp4e" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.jdt" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
@@ -73,5 +73,5 @@
         </dependencies>
       </location>
     </locations>
-    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: io.snyk.eclipse.plugin.tests
 Bundle-SymbolicName: io.snyk.eclipse.plugin.tests;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: Snyk
 Fragment-Host: io.snyk.eclipse.plugin
 Automatic-Module-Name: io.snyk

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>io.snyk.eclipse.plugin.tests</artifactId>
     <packaging>eclipse-test-plugin</packaging>

--- a/update-site/category.xml
+++ b/update-site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_2.0.0.qualifier.jar" id="io.snyk.scanner" version="2.0.0.qualifier">
+  <feature url="features/io.snyk.scanner_2.1.0.qualifier.jar" id="io.snyk.scanner" version="2.1.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security - Code, Open Source, IaC Configurations">

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.snyk</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <packaging>eclipse-repository</packaging>
 


### PR DESCRIPTION
### Description

Newer Eclipse and LSP4e versions depend on JDK 17. This PR creates a new version 2.1 of our plugin that supports and requires running with JDK 17 and synchronizes with upstream.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
