### PR TITLE
fix: parser error when token is empty

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/runner/ProcessRunner.java
@@ -127,7 +127,7 @@ public class ProcessRunner {
 
     String authMethod = Preferences.getInstance().getPref(Preferences.AUTHENTICATION_METHOD);
     String token = Preferences.getInstance().getAuthToken();
-    if (token != null && authMethod.equals(Preferences.AUTH_METHOD_OAUTH)) {
+    if (token != null && !token.isBlank() && authMethod.equals(Preferences.AUTH_METHOD_OAUTH)) {
       try {
 	      ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 	      var oauthToken = objectMapper.readValue(token, OAuthToken.class);


### PR DESCRIPTION
### Description
When the OAuth refresh token is expired, the user gets logged out. This caused an error message due to the attempt to parse an empty string.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

