### PR TITLE
chore: update plugin to compile against upstream LSP4e [HEAD-349]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Snyk Changelog
 
-## [2.0.0] - Unreleased
-### Changes
-- Increase LS version
-
 ## [2.1.0] - UNRELEASED
+### Changes
+- update plugin to cater to LSP4e API changes
+- cleanup redundant code
+- don't shutdown language server after some time of inactivity
+
+## [2.1.0] - v20230307.102901
 ### Changes
 - unpin LSP4e dependency - this requires running Eclipse on JDK 17+
 

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -165,7 +165,7 @@
       id="io.snyk.languageserver"
       label="Snyk Language Server"
       clientImpl="io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient"
-      lastDocumentDisconnectedTimeout="3600"
+      lastDocumentDisconnectedTimeout="3000000"
       singleton="true"
       makerType="io.snyk.languageserver.marker">
     </server>

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -66,17 +66,20 @@ public class SnykStartup implements IStartup {
             logError(exception);
           }
           downloading = false;
-          
+
+          monitor.subTask("Starting Snyk Language Server...");
+          startLanguageServer();
+
           if (Preferences.getInstance().getAuthToken().isBlank()) {
+            monitor.subTask("Starting Snyk Wizard to configure initial settings...");
             SnykWizard wizard = new SnykWizard();
             WizardDialog dialog = new WizardDialog(PlatformUI.getWorkbench().getDisplay().getActiveShell(), wizard);
             dialog.setBlockOnOpen(true);
             dialog.open();
           }
-          
-          startLanguageServer();
+
         });
-        
+
         return Status.OK_STATUS;
       }
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -17,6 +17,8 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.lsp4e.LanguageServersRegistry;
+import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -60,9 +62,6 @@ public class SnykStartup implements IStartup {
               monitor.subTask("Starting download of Snyk Language Server");
               download(monitor);
             }
-            
-            monitor.subTask("Starting Snyk Language Server...");
-            SnykLanguageServer.InitializeServer();
           } catch (Exception exception) {
             logError(exception);
           }
@@ -74,9 +73,20 @@ public class SnykStartup implements IStartup {
             dialog.setBlockOnOpen(true);
             dialog.open();
           }
+          
+          startLanguageServer();
         });
         
         return Status.OK_STATUS;
+      }
+
+      private void startLanguageServer() {
+        var definition = LanguageServersRegistry.getInstance().getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID);
+        try {
+          LanguageServiceAccessor.startLanguageServer(definition);
+        } catch (IOException e) {
+          logError(e);
+        }
       }
     };
     initJob.setPriority(Job.LONG);

--- a/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
@@ -3,6 +3,7 @@ package io.snyk.languageserver;
 import io.snyk.eclipse.plugin.Activator;
 import io.snyk.eclipse.plugin.properties.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
 import java.io.File;
 import java.util.Collections;
@@ -23,27 +24,10 @@ public class LsConfigurationUpdater {
 		var params = new DidChangeConfigurationParams();
 		params.setSettings(getCurrentSettings());
 
-		var definition = LanguageServersRegistry.getInstance().getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID);
-
-		if (definition == null) {
-			return;
-		}
-		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
-			if (project.isAccessible()) {
-				try {
-					var servers = Collections
-							.unmodifiableCollection(LanguageServiceAccessor.getLanguageServers(project, null));
-					for (LanguageServer ls : servers) {
-						var currentDefinition = LanguageServiceAccessor.resolveServerDefinition(ls);
-						if (currentDefinition.isEmpty() || !currentDefinition.get().id.equals(definition.id))
-							continue;
-						WorkspaceService workspaceService = ls.getWorkspaceService();
-						workspaceService.didChangeConfiguration(params);
-					}
-				} catch (Exception e) {
-					SnykLogger.logError(e);
-				}
-			}
+		SnykExtendedLanguageClient lc = SnykExtendedLanguageClient.getInstance();
+		if (lc != null) {
+    		var languageServer = lc.getConnectedLanguageServer();
+    		languageServer.getWorkspaceService().didChangeConfiguration(params);
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -22,6 +22,7 @@ import io.snyk.eclipse.plugin.properties.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.Lists;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 
+@SuppressWarnings("restriction")
 public class SnykLanguageServer extends ProcessStreamConnectionProvider implements StreamConnectionProvider {
   public static final String LANGUAGE_SERVER_ID = "io.snyk.languageserver";
   private final LsRuntimeEnvironment runtimeEnvironment;
@@ -46,18 +47,6 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
     setCommands(commands);
     setWorkingDirectory(workingDir);
     super.start();
-    new Job("Snyk: Sending preferences to Language Server") {
-      @Override
-      protected IStatus run(IProgressMonitor monitor) {
-        try {
-          new LsConfigurationUpdater().configurationChanged();
-          monitor.done();
-        } catch (RuntimeException e) {
-          SnykLogger.logError(e);
-        }
-        return Status.OK_STATUS;
-      }
-    }.schedule();
   }
 
   @Override
@@ -76,20 +65,5 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
       SnykLogger.logError(e);
     }
     return currentSettings;
-  }
-
-  public static void InitializeServer() {
-    var projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-    for (IProject project : projects) {
-      if (project.isAccessible()) {
-        try {
-          LanguageServiceAccessor.getLSWrapper(project,
-              LanguageServersRegistry.getInstance().getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID));
-        } catch (IOException e) {
-          SnykLogger.logError(e);
-          return;
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
### Description

The current plugin uses (by necessity) methods from LSP4e. Some of these have been removed and thus need a change in how to integrate. As the Eclipse LSP4e project is still in incubation, API changes may sometimes occur.

This corrects API usage and cleans up the integration with LSP4e, by fixing, changing and removing plugin workarounds.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
