### PR TITLE
fix: Remove custom path when launching language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.1.0] - UNRELEASED
 ### Changes
+- fix custom path configuration
+
+## [2.1.0] - v20230606.182718
+### Changes
 - update plugin to cater to LSP4e API changes
 - cleanup redundant code
 - don't shutdown language server after some time of inactivity

--- a/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsRuntimeEnvironment.java
@@ -74,7 +74,6 @@ public class LsRuntimeEnvironment {
   }
 
   public void updateEnvironment(Map<String, String> env) {
-    addPath(env);
     addIntegrationInfoToEnv(env);
     addProxyToEnv(env);
     addProductEnablement(env);


### PR DESCRIPTION
### Description

Remove custom path when launching language server, so that the path inside language server relies on the given configuration. 

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
