### PR TITLE
chore: bump LS Protocol version to 11 [IDE-236]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Snyk Security Changelog
 
+
 ## [2.1.0] - Unreleased
+
+### Changes
+- bumped the LS protocol version to 11 to support new commands introduced for global ignores
+
+## [2.1.0] - v20240313.174439
 
 ### Fixes
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/LsMetadataResponseHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/LsMetadataResponseHandler.java
@@ -14,7 +14,7 @@ public class LsMetadataResponseHandler implements ResponseHandler<String> {
 
   @Override
   public String handleResponse(HttpResponse httpResponse) {
-    String latestCliSupportingLSProtocolVersion = "10";
+    String latestCliSupportingLSProtocolVersion = "11";
     InputStream inputStream;
     try {
       inputStream = httpResponse.getEntity().getContent();


### PR DESCRIPTION
### Description

Bumps protocol version to 11. Don't merge before a CLI including https://github.com/snyk/snyk-ls/pull/485 is available.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
