### PR TITLE
fix: eclipse docs path in sync

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/docs/integrations/ide-tools/eclipse-plugin/README.md
+          SOURCE_PATH: ./docs/docs/integrate-with-snyk/use-snyk-in-your-ide/eclipse-plugin/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: snyk-eclipse-plugin
           DESTINATION_BRANCH: docs/automatic-gitbook-update


### PR DESCRIPTION
### Description

Docs sync didn't work anymore because the gitbook docs structure has changed. This PR adjusts the sync source URL to the correct one.

It works now - see here: [Synchronize Readme](https://github.com/snyk/snyk-eclipse-plugin/actions/runs/9284905759)

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
