### PR TITLE
fix: don't use quotes when generating ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.2.0] - Unreleased
 ### Changes
+- fixes the generated ignore id so that it is ignored during scanning  
+
+## [2.2.0] - v20240529.110806
+### Changes
 - require lsp4e 0.18.4 and lsp4j 0.22.0 as minimum versions (Eclipse 2024-03)
 - update release process & update sites to https://static.snyk.io/eclipse/preview and https://static.snyk.io/eclipse/stable
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/runner/SnykCliRunner.java
@@ -47,7 +47,7 @@ public class SnykCliRunner {
   }
 
   public ProcessResult snykIgnore(String id, File navigatePath) {
-    String idParam = "--id='" + id + "'";
+    String idParam = "--id=" + id + "";
 
     return snykRun(Lists.of(IGNORE_PARAM, idParam), Optional.of(navigatePath));
   }


### PR DESCRIPTION
### Description

Eclipse has functionality to generate ignores using the `.snyk` ignore file. At the moment, this works but the generated ignores is not being taken into account when running a scan. This is because of extra quotes that get added incorrectly to the ignore rule.

This PR removes the unnecessary quote when running the `snyk ignore` command.

When using the CLI this is how I generate ignores: `snyk ignore --id=SNYK-JS-MARKED-2342073`

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing


### Screenshots
I used https://github.com/snyk-labs/nodejs-goof to test.

There are 120 vulns without the ignore so I applied an ignore (I already had the one I tested earlier):
![Screenshot 2024-06-19 at 12 03 50](https://github.com/snyk/snyk-eclipse-plugin/assets/81559517/ddb542ff-3a47-49d1-b049-155008c9b5ca)

After the ignore was generated we don't get the ignored vuln showing up (there are 111 vulns):
![Screenshot 2024-06-19 at 12 06 52](https://github.com/snyk/snyk-eclipse-plugin/assets/81559517/9909d628-8c0f-4d54-a585-e1a0eaa08e92)

Matches what the CLI returns too:
![Screenshot 2024-06-19 at 12 07 25](https://github.com/snyk/snyk-eclipse-plugin/assets/81559517/4d613960-2ee3-41f4-888e-4647007a54e2)

**note** I did have to restart the sandbox because it wouldn't recognise `$snyk.scan` notifications anymore but I don't think it's because of this change:

