### PR TITLE
chore: changed the label of the endpoint configuration field

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizardConfigureAPIPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizardConfigureAPIPage.java
@@ -41,7 +41,7 @@ public class SnykWizardConfigureAPIPage extends WizardPage implements Listener {
     composite.setLayout(gl);
 
     Label endpointLabel = new Label(composite, SWT.NONE);
-    endpointLabel.setText("Specify the custom endpoint for Single Tenant setups (default: https://api.snyk.io):");
+    endpointLabel.setText("Specify the Snyk API endpoint. Useful for custom Multi Tenant or Single Tenant setup (default: https://api.snyk.io):");
 
     String endpointValue = initialEndpoint == null || initialEndpoint.isBlank() ? this.defaultEndpoint : initialEndpoint;
     endpoint = new Text(composite, SWT.BORDER);


### PR DESCRIPTION
### Description

chore: changed the label of the endpoint configuration field

Before it was only stating Single Tenant. Now it also includes Multi Tenant

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
