### PR TITLE
feat: add context menu actions [IDE-784]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/domain/ProductConstants.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/domain/ProductConstants.java
@@ -3,10 +3,10 @@ package io.snyk.eclipse.plugin.domain;
 import java.util.Map;
 
 public interface ProductConstants {
-	String SCAN_STATE_IN_PROGRESS="inProgress";
-	String SCAN_STATE_SUCCESS="success";
-	String SCAN_STATE_ERROR="error";
-		
+	String SCAN_STATE_IN_PROGRESS = "inProgress";
+	String SCAN_STATE_SUCCESS = "success";
+	String SCAN_STATE_ERROR = "error";
+
 	String SCAN_PARAMS_OSS = "oss";
 	String SCAN_PARAMS_CODE = "code";
 	String SCAN_PARAMS_IAC = "iac";
@@ -24,10 +24,20 @@ public interface ProductConstants {
 	String SEVERITY_HIGH = "high";
 	String SEVERITY_MEDIUM = "medium";
 	String SEVERITY_LOW = "low";
-	
+
+	String FILTERABLE_ISSUE_OPEN_SOURCE = "Open Source";
+	String FILTERABLE_ISSUE_CODE_SECURITY = "Code Security";
+	String FILTERABLE_ISSUE_CODE_QUALITY = "Code Quality";
+	String FILTERABLE_ISSUE_INFRASTRUCTURE_AS_CODE = "Infrastructure As Code";
+
+	Map<String, String> FILTERABLE_ISSUE_TYPE_TO_DISPLAY = Map.of(FILTERABLE_ISSUE_CODE_QUALITY, DISPLAYED_CODE_QUALITY,
+			FILTERABLE_ISSUE_CODE_SECURITY, DISPLAYED_CODE_SECURITY, FILTERABLE_ISSUE_INFRASTRUCTURE_AS_CODE,
+			DISPLAYED_IAC, FILTERABLE_ISSUE_OPEN_SOURCE, DISPLAYED_OSS);
+
 	Map<String, String> LSP_SOURCE_TO_SCAN_PARAMS = Map.of(DIAGNOSTIC_SOURCE_SNYK_CODE, SCAN_PARAMS_CODE,
 			DIAGNOSTIC_SOURCE_SNYK_IAC, SCAN_PARAMS_IAC, DIAGNOSTIC_SOURCE_SNYK_OSS, SCAN_PARAMS_OSS);
 
 	// code cannot be mapped easily
-	Map<String, String> SCAN_PARAMS_TO_DISPLAYED = Map.of(SCAN_PARAMS_OSS, DISPLAYED_OSS, SCAN_PARAMS_IAC, DISPLAYED_IAC);
+	Map<String, String> SCAN_PARAMS_TO_DISPLAYED = Map.of(SCAN_PARAMS_OSS, DISPLAYED_OSS, SCAN_PARAMS_IAC,
+			DISPLAYED_IAC);
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -3,6 +3,7 @@ package io.snyk.eclipse.plugin.views.snyktoolview;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -162,7 +163,9 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 								var result = CommandHandler.getInstance().ignoreIssue(issue).get(10, TimeUnit.SECONDS);
 								outputCommandResult(result); 
 								itn.setText("[ IGNORED ] " + itn.getText());
-								refreshTree();
+								Display.getDefault().asyncExec(() -> {
+									treeViewer.refresh(itn, true);
+								});
 							} catch (InterruptedException e) {
 								Thread.currentThread().interrupt();
 								SnykLogger.logError(e);
@@ -178,9 +181,7 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 			}
 
 			public boolean isEnabled() {
-				return selectedNode instanceof IssueTreeNode
-						&& !(getProduct().equals(ProductConstants.DISPLAYED_CODE_QUALITY)
-								|| getProduct().equals(ProductConstants.DISPLAYED_CODE_SECURITY));
+				return selectedNode instanceof IssueTreeNode && CommandHandler.getInstance().canBeIgnored(getProduct());
 			}
 
 			protected String getProduct() {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -1,5 +1,6 @@
 package io.snyk.eclipse.plugin.views.snyktoolview;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -203,7 +204,8 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 						@Override
 						protected IStatus run(IProgressMonitor monitor) {
 							try {
-								var result = CommandHandler.getInstance().monitorProject(project).get();
+								Path workingDir = ResourceUtils.getFullPath(project);
+								var result = CommandHandler.getInstance().monitorProject(workingDir).get();
 								outputCommandResult(result);
 							} catch (InterruptedException e) {
 								Thread.currentThread().interrupt();

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
@@ -13,6 +13,7 @@ import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 
 import io.snyk.eclipse.plugin.SnykStartup;
+import io.snyk.eclipse.plugin.utils.ResourceUtils;
 import io.snyk.languageserver.LsConfigurationUpdater;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
@@ -83,8 +84,8 @@ public class SnykWizard extends Wizard implements INewWizard {
 				SnykExtendedLanguageClient.getInstance().triggerAuthentication();
 				monitor.worked(20);
 				monitor.subTask("trusting workspace folders...");
-				var projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-				if (projects != null && projects.length > 0 && Arrays.stream(projects).filter(p -> p.isAccessible()).count() > 0) {
+				var projects = ResourceUtils.getAccessibleTopLevelProjects();
+				if (projects != null && projects.size()>0) {
 					SnykExtendedLanguageClient.getInstance().trustWorkspaceFolders();
 				}
 				monitor.worked(20);

--- a/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
+++ b/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
@@ -2,14 +2,18 @@ package io.snyk.languageserver;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.services.LanguageServer;
 
+import io.snyk.eclipse.plugin.domain.ProductConstants;
 import io.snyk.eclipse.plugin.utils.ResourceUtils;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
@@ -18,6 +22,8 @@ import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue
 public class CommandHandler {
 	private LanguageServer ls;
 	private static CommandHandler instance;
+	private static final Set<String> allowedProducts = Set.of(ProductConstants.DISPLAYED_IAC,
+			ProductConstants.DISPLAYED_OSS);
 
 	public CommandHandler(LanguageServer ls) {
 		this.ls = ls;
@@ -43,14 +49,28 @@ public class CommandHandler {
 	}
 
 	public CompletableFuture<Object> ignoreIssue(Issue issue) {
+		String displayProduct = ProductConstants.SCAN_PARAMS_TO_DISPLAYED.get(issue.product());
+		if (!canBeIgnored(displayProduct)) return CompletableFuture.completedFuture(null);
+		
 		Path workingDir = getWorkingDirectory(issue);
+		String pathArg = null;
 		List<Object> args = List.of(workingDir.toString(), "ignore", "--id=" + issue.additionalData().ruleId());
+
+		if (issue.product().equals(ProductConstants.SCAN_PARAMS_IAC)) {
+			Path relativePath = workingDir.relativize(Paths.get(issue.filePath()));
+			var separator = " > ";
+			pathArg = "--path=" + relativePath.toString() + separator
+					+ issue.additionalData().path().stream().collect(Collectors.joining(separator));
+			args = new ArrayList<Object>(args);
+			args.add(pathArg);
+		}
 		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
 	}
 
 	protected Path getWorkingDirectory(Issue issue) {
 		IProject project = ResourceUtils.getProjectByPath(Paths.get(issue.filePath()));
-		if (project == null) return Path.of(".");
+		if (project == null)
+			return Path.of(".");
 		var workingDir = ResourceUtils.getFullPath(project);
 		return workingDir;
 	}
@@ -58,6 +78,16 @@ public class CommandHandler {
 	public CompletableFuture<Object> monitorProject(Path path) {
 		List<Object> args = List.of(path.toString(), "monitor", "--all-projects");
 		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
+	}
+
+	/**
+	 * checks if a product can be ignored
+	 * @param product the DISPLAY product from ProductConstants
+	 * @return
+	 */
+	public boolean canBeIgnored(String product) {
+		if (product == null) return false;
+		return allowedProducts.contains(product);
 	}
 
 }

--- a/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
+++ b/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
@@ -3,7 +3,6 @@ package io.snyk.languageserver;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.ResourceBundle;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IProject;
@@ -51,13 +50,13 @@ public class CommandHandler {
 
 	protected Path getWorkingDirectory(Issue issue) {
 		IProject project = ResourceUtils.getProjectByPath(Paths.get(issue.filePath()));
+		if (project == null) return Path.of(".");
 		var workingDir = ResourceUtils.getFullPath(project);
 		return workingDir;
 	}
 
-	public CompletableFuture<Object> monitorProject(IProject project) {
-		Path workingDir = ResourceUtils.getFullPath(project);
-		List<Object> args = List.of(workingDir.toString(), "monitor", "--all-projects");
+	public CompletableFuture<Object> monitorProject(Path path) {
+		List<Object> args = List.of(path.toString(), "monitor", "--all-projects");
 		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
+++ b/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
@@ -1,0 +1,63 @@
+package io.snyk.languageserver;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+import io.snyk.eclipse.plugin.utils.ResourceUtils;
+import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
+import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue;
+
+public class CommandHandler {
+	private LanguageServer ls;
+	private static CommandHandler instance;
+
+	public CommandHandler(LanguageServer ls) {
+		this.ls = ls;
+	}
+
+	public static synchronized CommandHandler getInstance() {
+		if (instance == null) {
+			SnykExtendedLanguageClient lc = SnykExtendedLanguageClient.getInstance();
+			lc.ensureLanguageServerRunning();
+			instance = new CommandHandler(lc.getConnectedLanguageServer());
+		}
+		return instance;
+	}
+
+	public CompletableFuture<Object> executeCommand(@NonNull String command, List<Object> args) {
+		ExecuteCommandParams params = new ExecuteCommandParams(command, args);
+		try {
+			return ls.getWorkspaceService().executeCommand(params);
+		} catch (Exception e) {
+			SnykLogger.logError(e);
+		}
+		return CompletableFuture.completedFuture(null);
+	}
+
+	public CompletableFuture<Object> ignoreIssue(Issue issue) {
+		Path workingDir = getWorkingDirectory(issue);
+		List<Object> args = List.of(workingDir.toString(), "ignore", "--id=" + issue.additionalData().ruleId(), "--path=" + issue.filePath());
+		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
+	}
+
+	protected Path getWorkingDirectory(Issue issue) {
+		Path workingDir = Paths.get(issue.filePath()).getParent().toAbsolutePath();
+		return workingDir;
+	}
+
+	public CompletableFuture<Object> monitorProject(IProject project) {
+		Path workingDir = ResourceUtils.getFullPath(project);
+		List<Object> args = List.of(workingDir.toString(), "monitor", "--all-projects");
+		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
+	}
+
+}

--- a/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
+++ b/plugin/src/main/java/io/snyk/languageserver/CommandHandler.java
@@ -45,12 +45,13 @@ public class CommandHandler {
 
 	public CompletableFuture<Object> ignoreIssue(Issue issue) {
 		Path workingDir = getWorkingDirectory(issue);
-		List<Object> args = List.of(workingDir.toString(), "ignore", "--id=" + issue.additionalData().ruleId(), "--path=" + issue.filePath());
+		List<Object> args = List.of(workingDir.toString(), "ignore", "--id=" + issue.additionalData().ruleId());
 		return this.executeCommand(LsConstants.COMMAND_SNYK_CLI, args);
 	}
 
 	protected Path getWorkingDirectory(Issue issue) {
-		Path workingDir = Paths.get(issue.filePath()).getParent().toAbsolutePath();
+		IProject project = ResourceUtils.getProjectByPath(Paths.get(issue.filePath()));
+		var workingDir = ResourceUtils.getFullPath(project);
 		return workingDir;
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/LsConstants.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConstants.java
@@ -1,21 +1,22 @@
 package io.snyk.languageserver;
 
 public interface LsConstants {
-	public static final String COMMAND_LOGIN = "snyk.login";
-	public static final String COMMAND_GET_ACTIVE_USER = "snyk.getActiveUser";
-	public static final String COMMAND_WORKSPACE_SCAN = "snyk.workspace.scan";
-	public static final String COMMAND_WORKSPACE_FOLDER_SCAN = "snyk.workspaceFolder.scan";
-	public static final String COMMAND_TRUST_WORKSPACE_FOLDERS = "snyk.trustWorkspaceFolders";
-	public static final String COMMAND_GET_SETTINGS_SAST_ENABLED = "snyk.getSettingsSastEnabled";
-	public static final String COMMAND_GENERATE_ISSUE_DESCRIPTION = "snyk.generateIssueDescription";
-	public static final String COMMAND_REPORT_ANALYTICS = "snyk.reportAnalytics";
-	public static final String COMMAND_GET_FEATURE_FLAG_STATUS = "snyk.getFeatureFlagStatus";
-	public static final String COMMAND_CODE_FIX_DIFFS = "snyk.code.fixDiffs";
-	public static final String COMMAND_CODE_SUBMIT_FIX_FEEDBACK = "snyk.code.submitFixFeedback";
-	public static final String SNYK_HAS_AUTHENTICATED = "$/snyk.hasAuthenticated";
-	public static final String SNYK_IS_AVAILABLE_CLI = "$/snyk.isAvailableCli";
-	public static final String SNYK_ADD_TRUSTED_FOLDERS = "$/snyk.addTrustedFolders";
-	public static final String SNYK_SCAN = "$/snyk.scan";
-	public static final String SNYK_PUBLISH_DIAGNOSTICS_316 = "$/snyk.publishDiagnostics316";
-	public static final String SNYK_FOLDER_CONFIG = "$/snyk.folderConfigs";
+	String COMMAND_LOGIN = "snyk.login";
+	String COMMAND_GET_ACTIVE_USER = "snyk.getActiveUser";
+	String COMMAND_WORKSPACE_SCAN = "snyk.workspace.scan";
+	String COMMAND_WORKSPACE_FOLDER_SCAN = "snyk.workspaceFolder.scan";
+	String COMMAND_TRUST_WORKSPACE_FOLDERS = "snyk.trustWorkspaceFolders";
+	String COMMAND_GET_SETTINGS_SAST_ENABLED = "snyk.getSettingsSastEnabled";
+	String COMMAND_GENERATE_ISSUE_DESCRIPTION = "snyk.generateIssueDescription";
+	String COMMAND_REPORT_ANALYTICS = "snyk.reportAnalytics";
+	String COMMAND_GET_FEATURE_FLAG_STATUS = "snyk.getFeatureFlagStatus";
+	String COMMAND_CODE_FIX_DIFFS = "snyk.code.fixDiffs";
+	String COMMAND_CODE_SUBMIT_FIX_FEEDBACK = "snyk.code.submitFixFeedback";
+	String SNYK_HAS_AUTHENTICATED = "$/snyk.hasAuthenticated";
+	String SNYK_IS_AVAILABLE_CLI = "$/snyk.isAvailableCli";
+	String SNYK_ADD_TRUSTED_FOLDERS = "$/snyk.addTrustedFolders";
+	String SNYK_SCAN = "$/snyk.scan";
+	String SNYK_PUBLISH_DIAGNOSTICS_316 = "$/snyk.publishDiagnostics316";
+	String SNYK_FOLDER_CONFIG = "$/snyk.folderConfigs";
+	String COMMAND_SNYK_CLI = "snyk.executeCLI";
 }

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/messageObjects/scanResults/AdditionalData.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/messageObjects/scanResults/AdditionalData.java
@@ -1,5 +1,7 @@
 package io.snyk.languageserver.protocolextension.messageObjects.scanResults;
 
+import java.util.List;
+
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
 public record AdditionalData(
@@ -24,7 +26,8 @@ public record AdditionalData(
     String displayTargetFile,
     boolean isUpgradable,
     // IaC
-    String publicId
+    String publicId,
+    List<String> path
 ) {
 	public String customUIContent() {
 		var result = SnykExtendedLanguageClient.getInstance().getIssueDescription(key);

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/messageObjects/scanResults/Issue.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/messageObjects/scanResults/Issue.java
@@ -3,7 +3,7 @@ package io.snyk.languageserver.protocolextension.messageObjects.scanResults;
 import org.eclipse.lsp4j.Position;
 
 public record Issue(String id, String title, String severity, String filePath, Range range, boolean isIgnored,
-		boolean isNew, IgnoreDetails ignoreDetails, AdditionalData additionalData, String product) {
+		boolean isNew, String filterableIssueType, IgnoreDetails ignoreDetails, AdditionalData additionalData) {
 	public String getDisplayTitle() {
 		if (title == null || title.isEmpty()) {
 			return additionalData != null ? additionalData.message() : null;

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/CommandHandlerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/CommandHandlerTest.java
@@ -55,7 +55,7 @@ public class CommandHandlerTest extends LsBaseTest {
 
 	@Test
 	void testIgnore_CodeIssue_ignoreNotCalled() {
-		Issue issue = getIssue(ProductConstants.SCAN_PARAMS_CODE);
+		Issue issue = getIssue(ProductConstants.FILTERABLE_ISSUE_CODE_SECURITY);
 
 		cut.ignoreIssue(issue);
 
@@ -64,7 +64,7 @@ public class CommandHandlerTest extends LsBaseTest {
 	
 	@Test
 	void testIgnore_OSSIssue_pathIsNotAdded() {
-		Issue issue = getIssue(ProductConstants.SCAN_PARAMS_OSS);
+		Issue issue = getIssue(ProductConstants.FILTERABLE_ISSUE_OPEN_SOURCE);
 
 		cut.ignoreIssue(issue);
 		
@@ -74,14 +74,14 @@ public class CommandHandlerTest extends LsBaseTest {
 
 	@Test
 	void testIgnore_IaCIssue_pathIsAdded() {
-		Issue issue = getIssue(ProductConstants.SCAN_PARAMS_IAC);
+		Issue issue = getIssue(ProductConstants.FILTERABLE_ISSUE_INFRASTRUCTURE_AS_CODE);
 		
 		var expectedPath = "file > a > b > c";
 		
 
 		cut.ignoreIssue(issue);
 		
-		List<Object> args = List.of(".", "ignore", "--id=" + issue.additionalData().ruleId(), "--path="+expectedPath);
+		List<Object> args = List.of(".", "ignore", "--path="+expectedPath, "--id=" + issue.additionalData().publicId());
 		verifyExecuteCommand(args);
 	}
 
@@ -93,13 +93,13 @@ public class CommandHandlerTest extends LsBaseTest {
 		verifyExecuteCommand(args);
 	}
 
-	private Issue getIssue(String product) {
+	private Issue getIssue(String filterableIssueType) {
 		List<String> path = List.of("a", "b", "c");
 		var additionalData = Instancio.of(AdditionalData.class).set(Select.field(AdditionalData::path), path).create();
 		Issue issue = Instancio.of(Issue.class)
 				.set(Select.field(Issue::additionalData), additionalData)
 				.set(Select.field(Issue::additionalData), additionalData)
-				.set(Select.field(Issue::product), product)
+				.set(Select.field(Issue::filterableIssueType), filterableIssueType)
 				.set(Select.field(Issue::filePath), Paths.get(".", "file").toString())
 				.create();
 		return issue;

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/CommandHandlerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/CommandHandlerTest.java
@@ -1,0 +1,72 @@
+package io.snyk.languageserver.protocolextension;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.WorkspaceService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.snyk.eclipse.plugin.properties.preferences.Preferences;
+import io.snyk.languageserver.CommandHandler;
+import io.snyk.languageserver.LsBaseTest;
+import io.snyk.languageserver.LsConstants;
+import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue;
+
+public class CommandHandlerTest extends LsBaseTest {
+	private Preferences pref;
+	private LanguageServer lsMock;
+	private CommandHandler cut;
+	private WorkspaceService wsMock;
+	
+	@BeforeEach
+	protected void setUp() {
+		super.setUp();
+		pref = Preferences.getInstance();
+		// we don't want the wizard to pop up, so we set a dummy token
+		pref.store(Preferences.AUTH_TOKEN_KEY, "dummy");
+		pref.store(Preferences.MANAGE_BINARIES_AUTOMATICALLY, "false");
+		lsMock = Mockito.mock(LanguageServer.class);
+		
+		cut = new CommandHandler(lsMock);
+
+		wsMock = Mockito.mock(WorkspaceService.class);
+		when(lsMock.getWorkspaceService()).thenReturn(wsMock);
+	}
+
+	@AfterEach
+	protected void tearDown() {
+		super.tearDown();
+	}
+	
+	@Test
+	void testIgnoreIssue() {
+		Issue issue = Instancio.create(Issue.class);
+		cut.ignoreIssue(issue);
+		List<Object> args = List.of(".", "ignore", "--id="+issue.additionalData().ruleId());
+		verifyExecuteCommand(args);
+	}
+	
+	@Test
+	void testMonitor() {
+		Path path = Path.of(".");
+		cut.monitorProject(path);
+		List<Object> args = List.of(".", "monitor", "--all-projects");
+		verifyExecuteCommand(args);
+	}
+
+	private void verifyExecuteCommand(List<Object> args) {
+		ExecuteCommandParams params = new ExecuteCommandParams(LsConstants.COMMAND_SNYK_CLI, args);
+		verify(wsMock).executeCommand(eq(params));
+	}
+
+}


### PR DESCRIPTION
### Description

This PR adds a context menu to the tree. For issue nodes, Ignore & Monitor are enabled. For other nodes, only Monitor is enabled.

When clicking on the menu option, an action/job is started, that calls the CLI to ignore the issue or monitor the project. The monitored project is always the top-level project of the source file in the Eclipse workspace.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
