### PR TITLE
fix: prevent npe and user-facing error when eclipse is loaded with no projects open [IDE-845]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ContentRootNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ContentRootNode.java
@@ -75,7 +75,9 @@ public class ContentRootNode extends BaseTreeNode {
 	}
 
 	public void setPath(Path path) {
- 		this.path = path.normalize();
+		if (path != null) {
+			this.path = path.normalize();
+		}
 	}
 
 	public String getName() {


### PR DESCRIPTION
Simple fix to prevent user-facing error when eclipse is started with no projects open. Note that we still don't refresh plugins when a project is opened - I'll raise a separate ticket for that.

### Description

Previously, if eclipse was opened without a project, the plugin would crash and the user would see a garbled view with no obvious way to recover. Now, the Snyk plugin loads correctly.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
Before:
![image](https://github.com/user-attachments/assets/bbf9d45d-3fa3-4fc7-80ea-1952c0a96304)

After:
![image](https://github.com/user-attachments/assets/355b5cfe-44ff-4dea-a545-aa602f2d6c79)
