### PR TITLE
fix: make sure all images created are disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - add scan summary to custom UI, updating scan statuses live
 - added support for DeepCode AI Fixes
 - new severity icons
+- moved non-secret preferences to standard preference store, only use secure store for tokens
 
 ### Fixes
+- leak of image handles on big projects
+- startup and initialization errors - now waiting for init of secure store, download and config
 - fixes open & ignored issue filtering toggles
 
 ## [3.0.0]

--- a/feature/category.xml
+++ b/feature/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_3.0.0.qualifier.jar" id="io.snyk.scanner" version="3.0.0.qualifier">
+  <feature url="features/io.snyk.scanner_3.1.0.qualifier.jar" id="io.snyk.scanner" version="3.1.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security">

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="io.snyk.scanner"
       label="Snyk Security"
-      version="3.0.0.qualifier"
+      version="3.1.0.qualifier"
       provider-name="Snyk">
 
    <description url="https://snyk.io">

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.snyk.scanner</artifactId>

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: io.snyk.eclipse.plugin;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Activator: io.snyk.eclipse.plugin.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
@@ -7,10 +7,24 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import io.snyk.eclipse.plugin.utils.SnykIcons;
+
 /**
  * The activator class controls the plug-in life cycle
  */
 public class Activator extends AbstractUIPlugin {
+	private static final String ICONS_TRANSPARENT_PNG = "/icons/transparent.png";
+	private static final String ICONS_ENABLED_PNG = "/icons/enabled.png";
+	private static final String ICONS_SEVERITY_LOW_PNG = "/icons/severity_low.png";
+	private static final String ICONS_SEVERITY_MEDIUM_PNG = "/icons/severity_medium.png";
+	private static final String ICONS_SEVERITY_HIGH_PNG = "/icons/severity_high.png";
+	private static final String ICONS_SEVERITY_CRITICAL_PNG = "/icons/severity_critical.png";
+	private static final String ICONS_IAC_DISABLED_PNG = "/icons/iac_disabled.png";
+	private static final String ICONS_IAC_PNG = "/icons/iac.png";
+	private static final String ICONS_OSS_DISABLED_PNG = "/icons/oss_disabled.png";
+	private static final String ICONS_OSS_PNG = "/icons/oss.png";
+	private static final String ICONS_CODE_DISABLED_PNG = "/icons/code_disabled.png";
+	private static final String ICONS_CODE_PNG = "/icons/code.png";
 	// The plug-in ID
 	public static final String PLUGIN_ID = "io.snyk.eclipse.plugin"; //$NON-NLS-1$
 	public static final String PLUGIN_VERSION = Platform.getBundle(Activator.PLUGIN_ID).getVersion().toString();
@@ -18,8 +32,6 @@ public class Activator extends AbstractUIPlugin {
 
 	// The shared instance
 	private static Activator plugin;
-
-	private static ImageRegistry imageRegistry = null; // NOPMD
 
 	@Override
 	public void start(BundleContext context) throws Exception {
@@ -48,44 +60,35 @@ public class Activator extends AbstractUIPlugin {
 	 * @param path the path
 	 * @return the image descriptor
 	 */
-	public static ImageDescriptor getImageDescriptor(String key) {
-		Display display = Display.getDefault();
-
+	public ImageDescriptor getImageDescriptor(String key) {
 		// Use syncExec to invoke code on the SWT thread and wait for it to finish
-		display.syncExec(new Runnable() {
-			@Override
-			public void run() {
-				imageRegistry = getDefault().getImageRegistry();
-
+		return Display.getDefault().syncCall(() -> {
+			var imageDescriptor = getImageRegistry().getDescriptor(key);
+			if (imageDescriptor == null) {
+				imageDescriptor = ImageDescriptor.getMissingImageDescriptor();
 			}
-
+			return imageDescriptor;
 		});
-		if (imageRegistry == null) {
-			return ImageDescriptor.getMissingImageDescriptor();
-
-		}
-		return imageRegistry.getDescriptor(key);
 	}
 
 	@Override
 	protected void initializeImageRegistry(ImageRegistry registry) {
-		addImageToRegistry(registry, "CODE", "/icons/code.png");
-		addImageToRegistry(registry, "CODE_DISABLED", "/icons/code_disabled.png");
-		addImageToRegistry(registry, "OSS", "/icons/oss.png");
-		addImageToRegistry(registry, "OSS_DISABLED", "/icons/oss_disabled.png");
-		addImageToRegistry(registry, "IAC", "/icons/iac.png");
-		addImageToRegistry(registry, "IAC_DISABLED", "/icons/iac_disabled.png");
-		addImageToRegistry(registry, "SEVERITY_CRITICAL", "/icons/severity_critical.png");
-		addImageToRegistry(registry, "SEVERITY_HIGH", "/icons/severity_high.png");
-		addImageToRegistry(registry, "SEVERITY_MEDIUM", "/icons/severity_medium.png");
-		addImageToRegistry(registry, "SEVERITY_LOW", "/icons/severity_low.png");
-		addImageToRegistry(registry, "ENABLED", "/icons/enabled.png");
-		addImageToRegistry(registry, "DISABLED", "/icons/transparent.png");
+		addImageDescriptorToRegistry(registry, SnykIcons.CODE_ID, ICONS_CODE_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.CODE_DISABLED_ID, ICONS_CODE_DISABLED_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.OSS_ID, ICONS_OSS_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.OSS_DISABLED_ID, ICONS_OSS_DISABLED_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.IAC_ID, ICONS_IAC_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.IAC_DISABLED_ID, ICONS_IAC_DISABLED_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.SEVERITY_CRITICAL_ID, ICONS_SEVERITY_CRITICAL_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.SEVERITY_HIGH_ID, ICONS_SEVERITY_HIGH_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.SEVERITY_MEDIUM_ID, ICONS_SEVERITY_MEDIUM_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.SEVERITY_LOW_ID, ICONS_SEVERITY_LOW_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.ENABLED_ID, ICONS_ENABLED_PNG);
+		addImageDescriptorToRegistry(registry, SnykIcons.DISABLED_ID, ICONS_TRANSPARENT_PNG);
 	}
 
-	private void addImageToRegistry(ImageRegistry registry, String key, String path) {
+	private void addImageDescriptorToRegistry(ImageRegistry registry, String key, String path) {
 		ImageDescriptor descriptor = imageDescriptorFromPlugin(PLUGIN_ID, path);
 		registry.put(key, descriptor);
-
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
@@ -3,6 +3,7 @@ package io.snyk.eclipse.plugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -17,6 +18,8 @@ public class Activator extends AbstractUIPlugin {
 
 	// The shared instance
 	private static Activator plugin;
+
+	private static ImageRegistry imageRegistry = null; // NOPMD
 
 	@Override
 	public void start(BundleContext context) throws Exception {
@@ -46,7 +49,22 @@ public class Activator extends AbstractUIPlugin {
 	 * @return the image descriptor
 	 */
 	public static ImageDescriptor getImageDescriptor(String key) {
-		return getDefault().getImageRegistry().getDescriptor(key);
+		Display display = Display.getDefault();
+
+		// Use syncExec to invoke code on the SWT thread and wait for it to finish
+		display.syncExec(new Runnable() {
+			@Override
+			public void run() {
+				imageRegistry = getDefault().getImageRegistry();
+
+			}
+
+		});
+		if (imageRegistry == null) {
+			return ImageDescriptor.getMissingImageDescriptor();
+
+		}
+		return imageRegistry.getDescriptor(key);
 	}
 
 	@Override

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.SnykIcons;
 
 /**
@@ -61,6 +62,7 @@ public class Activator extends AbstractUIPlugin {
 	 * @return the image descriptor
 	 */
 	public ImageDescriptor getImageDescriptor(String key) {
+		if (Preferences.getInstance().isTest()) return null;
 		// Use syncExec to invoke code on the SWT thread and wait for it to finish
 		return Display.getDefault().syncCall(() -> {
 			var imageDescriptor = getImageRegistry().getDescriptor(key);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/Activator.java
@@ -2,6 +2,7 @@ package io.snyk.eclipse.plugin;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -9,43 +10,64 @@ import org.osgi.framework.BundleContext;
  * The activator class controls the plug-in life cycle
  */
 public class Activator extends AbstractUIPlugin {
-  // The plug-in ID
-  public static final String PLUGIN_ID = "io.snyk.eclipse.plugin"; //$NON-NLS-1$
-  public static final String PLUGIN_VERSION = Platform.getBundle(Activator.PLUGIN_ID).getVersion().toString();
-  public static final String INTEGRATION_NAME = "ECLIPSE";
+	// The plug-in ID
+	public static final String PLUGIN_ID = "io.snyk.eclipse.plugin"; //$NON-NLS-1$
+	public static final String PLUGIN_VERSION = Platform.getBundle(Activator.PLUGIN_ID).getVersion().toString();
+	public static final String INTEGRATION_NAME = "ECLIPSE";
 
-  // The shared instance
-  private static Activator plugin;
+	// The shared instance
+	private static Activator plugin;
 
-  @Override
-  public void start(BundleContext context) throws Exception {
-    super.start(context);
-    plugin = this;
-  }
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
 
-  @Override
-  public void stop(BundleContext context) throws Exception {
-    plugin = null;
-    super.stop(context);
-  }
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		super.stop(context);
+	}
 
-  /**
-   * Returns the shared instance
-   *
-   * @return the shared instance
-   */
-  public static Activator getDefault() {
-    return plugin;
-  }
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
 
-  /**
-   * Returns an image descriptor for the image file at the given plug-in relative
-   * path
-   *
-   * @param path the path
-   * @return the image descriptor
-   */
-  public static ImageDescriptor getImageDescriptor(String path) {
-    return imageDescriptorFromPlugin(PLUGIN_ID, path);
-  }
+	/**
+	 * Returns an image descriptor for the image file at the given plug-in relative
+	 * path
+	 *
+	 * @param path the path
+	 * @return the image descriptor
+	 */
+	public static ImageDescriptor getImageDescriptor(String key) {
+		return getDefault().getImageRegistry().getDescriptor(key);
+	}
+
+	@Override
+	protected void initializeImageRegistry(ImageRegistry registry) {
+		addImageToRegistry(registry, "CODE", "/icons/code.png");
+		addImageToRegistry(registry, "CODE_DISABLED", "/icons/code_disabled.png");
+		addImageToRegistry(registry, "OSS", "/icons/oss.png");
+		addImageToRegistry(registry, "OSS_DISABLED", "/icons/oss_disabled.png");
+		addImageToRegistry(registry, "IAC", "/icons/iac.png");
+		addImageToRegistry(registry, "IAC_DISABLED", "/icons/iac_disabled.png");
+		addImageToRegistry(registry, "SEVERITY_CRITICAL", "/icons/severity_critical.png");
+		addImageToRegistry(registry, "SEVERITY_HIGH", "/icons/severity_high.png");
+		addImageToRegistry(registry, "SEVERITY_MEDIUM", "/icons/severity_medium.png");
+		addImageToRegistry(registry, "SEVERITY_LOW", "/icons/severity_low.png");
+		addImageToRegistry(registry, "ENABLED", "/icons/enabled.png");
+		addImageToRegistry(registry, "DISABLED", "/icons/transparent.png");
+	}
+
+	private void addImageToRegistry(ImageRegistry registry, String key, String path) {
+		ImageDescriptor descriptor = imageDescriptorFromPlugin(PLUGIN_ID, path);
+		registry.put(key, descriptor);
+
+	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -16,6 +16,7 @@ import org.osgi.framework.Bundle;
 
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.ResourceUtils;
+import io.snyk.eclipse.plugin.utils.SnykLogger;
 
 public class BaseHtmlProvider {
 	private final Random random = new Random();
@@ -142,7 +143,7 @@ public class BaseHtmlProvider {
 		try {
 			fontSize = getCurrentTheme().getFontRegistry().getFontData(JFaceResources.TEXT_FONT)[0].getHeight();
 		} catch (IllegalStateException e) {
-			// TODO improve the logic here. Expected only in unit tests.
+			SnykLogger.logInfo("cannot get default font-size from Eclipse, using default (13)");
 		}
 		return fontSize;
 	}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -137,7 +137,6 @@ public class BaseHtmlProvider {
 		return htmlStyled;
 	}
 
-	@SuppressWarnings("PMD.EmptyCatchBlock")
 	private int getDefaultFontSize() {
 		int fontSize =  13;
 		try {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
@@ -14,6 +14,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.languageserver.SnykLanguageServer;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
 public class PreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
@@ -134,6 +135,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 
 	private void disableSnykCodeIfOrgDisabled() {
 		CompletableFuture.runAsync(() -> {
+			SnykLanguageServer.waitForInit();
 			boolean isSastEnabled;
 			try {
 				isSastEnabled = SnykExtendedLanguageClient.getInstance().getSastEnabled();

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/TokenFieldEditor.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/TokenFieldEditor.java
@@ -1,20 +1,26 @@
 package io.snyk.eclipse.plugin.preferences;
 
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 
-
 public class TokenFieldEditor extends StringFieldEditor {
-  protected TokenFieldEditor(Preferences preferences, String name, String labelText,
-                             Composite parent) {
-    super(name, labelText, 80, parent);
-    setPreferenceStore(preferences.getSecureStore()); //NOPMD
-    getTextControl().setEchoChar('*'); //NOPMD
-  }
+	private Preferences preferences;
 
-  public void emptyTextfield() {
-    setStringValue("");
-  }
+	protected TokenFieldEditor(Preferences preferences, String name, String labelText, Composite parent) {
+		super(name, labelText, 80, parent);
+		this.preferences = preferences;
+		super.setPreferenceStore(preferences.getSecureStore()); // NOPMD
+		getTextControl().setEchoChar('*'); // NOPMD
+	}
 
+	public void emptyTextfield() {
+		setStringValue("");
+	}
 
+	@Override
+	public void setPreferenceStore(IPreferenceStore store) {
+		// we don't let the page override the preference store to a non-secure store
+		super.setPreferenceStore(preferences.getSecureStore());
+	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
@@ -5,21 +5,20 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import io.snyk.eclipse.plugin.Activator;
 
 public class SnykIcons {
-	public static final ImageDescriptor CODE = Activator.getImageDescriptor("/icons/code.png");
-	public static final ImageDescriptor CODE_DISABLED = Activator.getImageDescriptor("/icons/code_disabled.png");
+	public static final ImageDescriptor CODE = Activator.getImageDescriptor("CODE");
+	public static final ImageDescriptor CODE_DISABLED = Activator.getImageDescriptor("CODE_DISABLED");
 
-	public static final ImageDescriptor OSS = Activator.getImageDescriptor("/icons/oss.png");
-	public static final ImageDescriptor OSS_DISABLED = Activator.getImageDescriptor("/icons/oss_disabled.png");
+	public static final ImageDescriptor OSS = Activator.getImageDescriptor("OSS");
+	public static final ImageDescriptor OSS_DISABLED = Activator.getImageDescriptor("OSS_DISABLED");
 
-	public static final ImageDescriptor IAC = Activator.getImageDescriptor("/icons/iac.png");
-	public static final ImageDescriptor IAC_DISABLED = Activator.getImageDescriptor("/icons/iac_disabled.png");
+	public static final ImageDescriptor IAC = Activator.getImageDescriptor("IAC");
+	public static final ImageDescriptor IAC_DISABLED = Activator.getImageDescriptor("IAC_DISABLED");
 
-	public static final ImageDescriptor SEVERITY_CRITICAL = Activator
-			.getImageDescriptor("/icons/severity_critical.png");
-	public static final ImageDescriptor SEVERITY_HIGH = Activator.getImageDescriptor("/icons/severity_high.png");
-	public static final ImageDescriptor SEVERITY_MEDIUM = Activator.getImageDescriptor("/icons/severity_medium.png");
-	public static final ImageDescriptor SEVERITY_LOW = Activator.getImageDescriptor("/icons/severity_low.png");
+	public static final ImageDescriptor SEVERITY_CRITICAL = Activator.getImageDescriptor("SEVERITY_CRITICAL");
+	public static final ImageDescriptor SEVERITY_HIGH = Activator.getImageDescriptor("SEVERITY_HIGH");
+	public static final ImageDescriptor SEVERITY_MEDIUM = Activator.getImageDescriptor("SEVERITY_MEDIUM");
+	public static final ImageDescriptor SEVERITY_LOW = Activator.getImageDescriptor("SEVERITY_LOW");
 
-	public static final ImageDescriptor ENABLED = Activator.getImageDescriptor("/icons/enabled.png");
-	public static final ImageDescriptor DISABLED = Activator.getImageDescriptor("/icons/transparent.png");
+	public static final ImageDescriptor ENABLED = Activator.getImageDescriptor("ENABLED");
+	public static final ImageDescriptor DISABLED = Activator.getImageDescriptor("DISABLED");
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
@@ -27,7 +27,6 @@ public class SnykIcons {
 		Display.getDefault().syncExec(() -> {
 			final var imageRegistry = Activator.getDefault().getImageRegistry();
 			imageRegistry.put(id, imageDescriptor);
-			imageRegistry.put(id, imageDescriptor.createImage(true));
 		});
 
 	}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
@@ -1,6 +1,7 @@
 package io.snyk.eclipse.plugin.utils;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.widgets.Display;
 
 import io.snyk.eclipse.plugin.Activator;
 
@@ -17,14 +18,17 @@ public class SnykIcons {
 	public static final String SEVERITY_LOW_ID = "SEVERITY_LOW";
 	public static final String ENABLED_ID = "ENABLED";
 	public static final String DISABLED_ID = "DISABLED";
-		
+
 	public static final ImageDescriptor getImageDescriptor(String descriptorId) {
 		return Activator.getDefault().getImageDescriptor(descriptorId);
 	}
-	
+
 	public static final void addImageDescriptorToRegistry(String id, ImageDescriptor imageDescriptor) {
-		final var imageRegistry = Activator.getDefault().getImageRegistry();
-		imageRegistry.put(id, imageDescriptor);
-		imageRegistry.put(id, imageDescriptor.createImage(true));
+		Display.getDefault().syncExec(() -> {
+			final var imageRegistry = Activator.getDefault().getImageRegistry();
+			imageRegistry.put(id, imageDescriptor);
+			imageRegistry.put(id, imageDescriptor.createImage(true));
+		});
+
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykIcons.java
@@ -5,20 +5,26 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import io.snyk.eclipse.plugin.Activator;
 
 public class SnykIcons {
-	public static final ImageDescriptor CODE = Activator.getImageDescriptor("CODE");
-	public static final ImageDescriptor CODE_DISABLED = Activator.getImageDescriptor("CODE_DISABLED");
-
-	public static final ImageDescriptor OSS = Activator.getImageDescriptor("OSS");
-	public static final ImageDescriptor OSS_DISABLED = Activator.getImageDescriptor("OSS_DISABLED");
-
-	public static final ImageDescriptor IAC = Activator.getImageDescriptor("IAC");
-	public static final ImageDescriptor IAC_DISABLED = Activator.getImageDescriptor("IAC_DISABLED");
-
-	public static final ImageDescriptor SEVERITY_CRITICAL = Activator.getImageDescriptor("SEVERITY_CRITICAL");
-	public static final ImageDescriptor SEVERITY_HIGH = Activator.getImageDescriptor("SEVERITY_HIGH");
-	public static final ImageDescriptor SEVERITY_MEDIUM = Activator.getImageDescriptor("SEVERITY_MEDIUM");
-	public static final ImageDescriptor SEVERITY_LOW = Activator.getImageDescriptor("SEVERITY_LOW");
-
-	public static final ImageDescriptor ENABLED = Activator.getImageDescriptor("ENABLED");
-	public static final ImageDescriptor DISABLED = Activator.getImageDescriptor("DISABLED");
+	public static final String CODE_ID = "CODE";
+	public static final String CODE_DISABLED_ID = "CODE_DISABLED";
+	public static final String OSS_ID = "OSS";
+	public static final String OSS_DISABLED_ID = "OSS_DISABLED";
+	public static final String IAC_ID = "IAC";
+	public static final String IAC_DISABLED_ID = "IAC_DISABLED";
+	public static final String SEVERITY_CRITICAL_ID = "SEVERITY_CRITICAL";
+	public static final String SEVERITY_HIGH_ID = "SEVERITY_HIGH";
+	public static final String SEVERITY_MEDIUM_ID = "SEVERITY_MEDIUM";
+	public static final String SEVERITY_LOW_ID = "SEVERITY_LOW";
+	public static final String ENABLED_ID = "ENABLED";
+	public static final String DISABLED_ID = "DISABLED";
+		
+	public static final ImageDescriptor getImageDescriptor(String descriptorId) {
+		return Activator.getDefault().getImageDescriptor(descriptorId);
+	}
+	
+	public static final void addImageDescriptorToRegistry(String id, ImageDescriptor imageDescriptor) {
+		final var imageRegistry = Activator.getDefault().getImageRegistry();
+		imageRegistry.put(id, imageDescriptor);
+		imageRegistry.put(id, imageDescriptor.createImage(true));
+	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
@@ -65,7 +65,7 @@ public class BaseTreeNode extends TreeNode {
 
 	protected ImageDescriptor getImageDescriptor(IResource object) {
 		ILabelProvider labelProvider = null;
-		Image image = null;
+		Image image;
 
 		try {
 			labelProvider = WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider();
@@ -81,15 +81,6 @@ public class BaseTreeNode extends TreeNode {
 			SnykLogger.logError(e);
 			return null;
 		} finally {
-			disposeResources(labelProvider, image);
-		}
-	}
-
-	private void disposeResources(ILabelProvider labelProvider, Image image) {
-		if (image != null && !image.isDisposed()) {
-			image.dispose();
-		}
-		if (labelProvider != null) {
 			labelProvider.dispose();
 		}
 	}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
@@ -19,15 +19,12 @@ import io.snyk.eclipse.plugin.utils.SnykLogger;
 public class BaseTreeNode extends TreeNode {
 	private ImageDescriptor imageDescriptor;
 	private String text = "";
+	private Object value;
 
 	public BaseTreeNode(Object value) {
 		super(value);
 		if (value instanceof String)
 			this.text = value.toString();
-	}
-
-	public void setValue(Object value) {
-		this.value = value;
 	}
 
 	public void addChild(BaseTreeNode child) {
@@ -41,7 +38,12 @@ public class BaseTreeNode extends TreeNode {
 		}
 		child.setParent(this);
 		list.add(child);
-		this.setChildren(list.toArray(new BaseTreeNode[list.size()]));
+
+		// Calls to a collection's `toArray(E[])` method should specify a target array
+		// of zero size. This allows the JVM
+		// to optimize the memory allocation and copying as much as possible.
+		// https://shipilev.net/blog/2016/arrays-wisdom-ancients/
+		this.setChildren(list.toArray(new BaseTreeNode[0]));
 	}
 
 	public void removeChildren() {
@@ -104,6 +106,10 @@ public class BaseTreeNode extends TreeNode {
 		this.text = text;
 	}
 
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
 	@Override
 	public String toString() {
 		return this.value.toString();
@@ -112,8 +118,6 @@ public class BaseTreeNode extends TreeNode {
 	public void reset() {
 		this.removeChildren();
 		this.text = "";
-		this.value = null;
-		this.imageDescriptor = null;
 	}
 
 	/**

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BaseTreeNode.java
@@ -14,6 +14,8 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 
+import io.snyk.eclipse.plugin.utils.SnykIcons;
+
 public class BaseTreeNode extends TreeNode {
 	private ImageDescriptor imageDescriptor;
 	private String text = "";
@@ -39,7 +41,7 @@ public class BaseTreeNode extends TreeNode {
 		}
 		child.setParent(this);
 		list.add(child);
-		this.setChildren(list.toArray(new BaseTreeNode[list.size()]));
+		this.setChildren(list.toArray(new BaseTreeNode[0]));
 	}
 
 	public void removeChildren() {
@@ -55,20 +57,22 @@ public class BaseTreeNode extends TreeNode {
 		setChildren(new BaseTreeNode[0]);
 	}
 
-	public void setImageDescriptor(ImageDescriptor imageDescriptor) {
+	public final void setImageDescriptor(ImageDescriptor imageDescriptor) {
 		this.imageDescriptor = imageDescriptor;
 	}
 	
-	protected ImageDescriptor getImageDescriptor(IResource object) {
-		ILabelProvider labelProvider = WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider();
+	protected ImageDescriptor getImageDescriptor(IResource object) {	
+		ILabelProvider labelProvider = null;
 		try {
+			labelProvider =  WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider();
 			Image image = labelProvider.getImage(object);
 			if (image == null || image.isDisposed())
 				return null;
 			
-			return getImageDescriptorFromImage(image);
+			imageDescriptor = getImageDescriptorFromImage(image);
+			return imageDescriptor;
 		} finally {
-			labelProvider.dispose();
+			if (labelProvider != null) labelProvider.dispose();
 		}
 	}
 
@@ -92,8 +96,8 @@ public class BaseTreeNode extends TreeNode {
 	public void reset() {
 		this.removeChildren();
 		this.text = "";
-		this.value = null;
-		this.imageDescriptor = null;
+		this.value = null; // NOPMD by bdoetsch on 3/12/25, 10:27 AM
+		this.imageDescriptor = null; // NOPMD by bdoetsch on 3/12/25, 10:27 AM
 	}
 
 	/**
@@ -104,7 +108,7 @@ public class BaseTreeNode extends TreeNode {
 	public String getDetails() {
 		return "";
 	}
-
+	
 	protected ImageDescriptor getImageDescriptorFromImage(Image image) {
 		final var data = image.getImageData();
 	
@@ -114,6 +118,7 @@ public class BaseTreeNode extends TreeNode {
 				return data;
 			}
 		};
-		return ImageDescriptor.createFromImageDataProvider(provider);
+		final var fromImageDataProvider = ImageDescriptor.createFromImageDataProvider(provider);
+		return fromImageDataProvider;
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/IssueTreeNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/IssueTreeNode.java
@@ -28,13 +28,13 @@ public class IssueTreeNode extends BaseTreeNode {
 	public ImageDescriptor getImageDescriptor() {
 		switch (getIssue().severity()) {
 		case ProductConstants.SEVERITY_CRITICAL:
-			return SnykIcons.SEVERITY_CRITICAL;
+			return SnykIcons.getImageDescriptor(SnykIcons.SEVERITY_CRITICAL_ID);
 		case ProductConstants.SEVERITY_HIGH:
-			return SnykIcons.SEVERITY_HIGH;
+			return SnykIcons.getImageDescriptor(SnykIcons.SEVERITY_HIGH_ID);
 		case ProductConstants.SEVERITY_MEDIUM:
-			return SnykIcons.SEVERITY_MEDIUM;
+			return SnykIcons.getImageDescriptor(SnykIcons.SEVERITY_MEDIUM_ID);
 		case ProductConstants.SEVERITY_LOW:
-			return SnykIcons.SEVERITY_LOW;
+			return SnykIcons.getImageDescriptor(SnykIcons.SEVERITY_LOW_ID);
 		default:
 			return super.getImageDescriptor();
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ProductTreeNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ProductTreeNode.java
@@ -17,26 +17,23 @@ public class ProductTreeNode extends BaseTreeNode {
 	private String errorMessage;
 	private String prefEnablementKey;
 
-	private ProductTreeNode(String value, ImageDescriptor ossDescriptor, ImageDescriptor iacDescriptor,
-			ImageDescriptor codeQualityDesciptor, ImageDescriptor codeSecurityDescriptor) {
-		super(value);
+	private final void initialize(String value) {
 		this.product = value;
-
 		switch (value) {
 		case ProductConstants.DISPLAYED_OSS:
-			setImageDescriptor(ossDescriptor);
+			setImageDescriptor(SnykIcons.getImageDescriptor(SnykIcons.OSS_ID));
 			prefEnablementKey = Preferences.ACTIVATE_SNYK_OPEN_SOURCE;
 			break;
 		case ProductConstants.DISPLAYED_IAC:
-			setImageDescriptor(iacDescriptor);
+			setImageDescriptor(SnykIcons.getImageDescriptor(SnykIcons.IAC_ID));
 			prefEnablementKey = Preferences.ACTIVATE_SNYK_IAC;
 			break;
 		case ProductConstants.DISPLAYED_CODE_QUALITY:
-			setImageDescriptor(codeQualityDesciptor);
+			setImageDescriptor(SnykIcons.getImageDescriptor(SnykIcons.CODE_ID));
 			prefEnablementKey = Preferences.ACTIVATE_SNYK_CODE_QUALITY;
 			break;
 		case ProductConstants.DISPLAYED_CODE_SECURITY:
-			setImageDescriptor(codeSecurityDescriptor);
+			setImageDescriptor(SnykIcons.getImageDescriptor(SnykIcons.CODE_ID));
 			prefEnablementKey = Preferences.ACTIVATE_SNYK_CODE_SECURITY;
 			break;
 		default:
@@ -45,12 +42,8 @@ public class ProductTreeNode extends BaseTreeNode {
 	}
 
 	public ProductTreeNode(String value) {
-		this(value, SnykIcons.OSS, SnykIcons.IAC, SnykIcons.CODE, SnykIcons.CODE);
-	}
-
-	// For testing
-	public ProductTreeNode(String value, ImageDescriptor imageDescriptor) {
-		this(value, imageDescriptor, imageDescriptor, imageDescriptor, imageDescriptor);
+		super(value);
+		initialize(value);
 	}
 
 	@Override
@@ -96,12 +89,12 @@ public class ProductTreeNode extends BaseTreeNode {
 			throw new IllegalArgumentException("value of product node must be a string");
 
 		// Avoid reassigning 'value' to '(disabled)'
-		String tempValue = value.toString();
+		cleanedValue = value.toString();
 		if (!isEnabled()) {
-			tempValue = "(disabled)";
+			cleanedValue = "(disabled)";
 		}
 
-		cleanedValue = removePrefix(tempValue);
+		cleanedValue = removePrefix(cleanedValue);
 
 		// we don't want to override the product text
 		if (!cleanedValue.isBlank()) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/RootNode.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/RootNode.java
@@ -10,9 +10,10 @@ import io.snyk.eclipse.plugin.utils.ResourceUtils;
 public class RootNode extends BaseTreeNode {
 	public RootNode() {
 		super("");
-		reset();
+		reset(); // NOPMD by bdoetsch on 3/12/25, 11:48 AM
 	}
 
+	@Override
 	public void reset() {
 		super.reset();
 		List<IProject> openProjects = ResourceUtils.getAccessibleTopLevelProjects();
@@ -25,7 +26,7 @@ public class RootNode extends BaseTreeNode {
 
 		for (IProject project : openProjects) {
 			Path path = ResourceUtils.getFullPath(project);
-			BaseTreeNode contentRoot = new ContentRootNode(project.getName(), path);
+			BaseTreeNode contentRoot = new ContentRootNode(project.getName(), path); // NOPMD by bdoetsch on 3/12/25, 11:48 AM
 			this.addChild(contentRoot);
 		}
 	}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/BaseHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/BaseHandler.java
@@ -32,8 +32,8 @@ public class BaseHandler extends AbstractHandler implements IElementUpdater, IHa
 	protected String preferenceKey;
 	
 	public BaseHandler() {
-		iconEnabled = SnykIcons.ENABLED;
-		iconDisabled = SnykIcons.DISABLED;
+		iconEnabled = SnykIcons.getImageDescriptor(SnykIcons.ENABLED_ID);
+		iconDisabled = SnykIcons.getImageDescriptor(SnykIcons.DISABLED_ID);
 	}
 
 	@Override

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/EnableAllProductHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/EnableAllProductHandler.java
@@ -16,8 +16,8 @@ import io.snyk.eclipse.plugin.utils.SnykIcons;
 public class EnableAllProductHandler extends BaseHandler implements IElementUpdater {
 	public EnableAllProductHandler() {
 		super();
-		iconEnabled = SnykIcons.ENABLED;
-		iconDisabled = SnykIcons.DISABLED;
+		iconEnabled = SnykIcons.getImageDescriptor(SnykIcons.ENABLED_ID);
+		iconDisabled = SnykIcons.getImageDescriptor(SnykIcons.DISABLED_ID);
 	}
 
 	@Override

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/providers/TreeLabelProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/providers/TreeLabelProvider.java
@@ -7,11 +7,12 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 
 import io.snyk.eclipse.plugin.views.snyktoolview.BaseTreeNode;
 
 public class TreeLabelProvider implements ILabelProvider {
-	private static Map<ImageDescriptor, Image> images = new ConcurrentHashMap<ImageDescriptor, Image>();
+	private Map<ImageDescriptor, Image> images = new ConcurrentHashMap<ImageDescriptor, Image>();
 
 	public TreeLabelProvider() {
 	}
@@ -41,7 +42,8 @@ public class TreeLabelProvider implements ILabelProvider {
 		synchronized (images) {
 			Image image = images.get(imageDescriptor);
 			if (image == null || image.isDisposed()) {
-				images.put(imageDescriptor, imageDescriptor.createImage());
+				final var resource = imageDescriptor.createResource(Display.getDefault());
+				images.put(imageDescriptor, (Image) resource);
 			}
 			return images.get(imageDescriptor);
 		}
@@ -55,8 +57,7 @@ public class TreeLabelProvider implements ILabelProvider {
 	@Override
 	public void dispose() {
 		for (var entry : images.entrySet()) {
-			var image = entry.getValue();
-			image.dispose();
+			entry.getKey().destroyResource(entry.getValue());
 		}
 		images.clear();
 	}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
@@ -7,7 +7,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardDialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.snyk</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -134,7 +134,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jarsigner-plugin</artifactId>
-                        <version>3.0.0</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign</id>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <packaging>eclipse-target-definition</packaging>
 </project>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -3,20 +3,20 @@
 <target name="Snyklipse">
     <locations>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
+        <repository location="https://download.eclipse.org/eclipse/updates/4.34/"/>
         <unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
         <unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
       </location>
 
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <repository location="https://download.eclipse.org/releases/latest"/>
+        <repository location="https://download.eclipse.org/releases/2024-12/"/>
         <unit id="org.eclipse.platform.ide" version="0.0.0"/>
         <unit id="org.eclipse.ui.genericeditor" version="0.0.0"/>
         <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
       </location>
 
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <repository location="https://download.eclipse.org/lsp4e/releases/latest/"/>
+        <repository location="https://download.eclipse.org/lsp4e/releases/0.27.1/"/>
         <unit id="org.eclipse.lsp4e" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.jdt" version="0.0.0"/>
         <unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: io.snyk.eclipse.plugin.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: io.snyk.eclipse.plugin.tests;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Snyk
 Fragment-Host: io.snyk.eclipse.plugin
 Automatic-Module-Name: io.snyk

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.snyk.eclipse.plugin.tests</artifactId>

--- a/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
@@ -65,8 +65,6 @@ class PreferencesTest {
 		assertEquals("true", preferences.getPref(FILTER_IGNORES_SHOW_OPEN_ISSUES));
 		assertEquals("false", preferences.getPref(FILTER_IGNORES_SHOW_IGNORED_ISSUES));
 		assertEquals("false", preferences.getPref(FILTER_SHOW_ONLY_FIXABLE));
-		assertEquals("true", preferences.getPref(SEND_ERROR_REPORTS));
-		assertEquals("true", preferences.getPref(ENABLE_TELEMETRY));
 		assertEquals("true", preferences.getPref(MANAGE_BINARIES_AUTOMATICALLY));
 		assertEquals("1", preferences.getPref(LSP_VERSION));
 		assertEquals("false", preferences.getPref(IS_GLOBAL_IGNORES_FEATURE_ENABLED));
@@ -86,8 +84,9 @@ class PreferencesTest {
 					.thenReturn("token");
 
 			Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(), new InMemorySecurePreferenceStore());
+			prefs.waitForSecureStorage();
 
-			assertEquals(prefs.getAuthToken(), "token");
+			assertEquals("token", prefs.getAuthToken());
 		}
 	}
 
@@ -111,7 +110,7 @@ class PreferencesTest {
 
 			Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(), new InMemorySecurePreferenceStore());
 
-			assertEquals(prefs.getPref(Preferences.ORGANIZATION_KEY), "myOrg");
+			assertEquals("myOrg",prefs.getPref(Preferences.ORGANIZATION_KEY));
 		}
 	}
 

--- a/tests/src/test/java/io/snyk/languageserver/LsBaseTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsBaseTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.graphics.Image;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
@@ -26,8 +27,6 @@ public class LsBaseTest {
     protected IProxyService proxyServiceMock;
 
     private File lsFile = getTempFile();
-    @Mock
-    private ImageRegistry imageRegistry;
     protected Preferences prefs;
 
     @BeforeEach
@@ -43,10 +42,6 @@ public class LsBaseTest {
         this.prefs.setSecureStorageReady(true);
         PreferencesUtils.setPreferences(prefs);
         this.prefs.setTest(true);
-
-        MockitoAnnotations.openMocks(this);
-//		when(imageRegistry.get(anyString())).thenReturn(mock(Image.class));
-        when(imageRegistry.getDescriptor(anyString())).thenReturn(mock(ImageDescriptor.class));
 
         when(environment.getArch()).thenReturn("amd64");
         when(environment.getOs()).thenReturn("linux");

--- a/tests/src/test/java/io/snyk/languageserver/LsBaseTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsBaseTest.java
@@ -1,5 +1,6 @@
 package io.snyk.languageserver;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearAllCaches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -8,8 +9,12 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import io.snyk.eclipse.plugin.preferences.InMemoryPreferenceStore;
 import io.snyk.eclipse.plugin.preferences.InMemorySecurePreferenceStore;
@@ -17,46 +22,52 @@ import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.properties.preferences.PreferencesUtils;
 
 public class LsBaseTest {
-  protected LsRuntimeEnvironment environment = null;
-  protected IProxyService proxyServiceMock;
+    protected LsRuntimeEnvironment environment = null;
+    protected IProxyService proxyServiceMock;
 
-  private File lsFile = getTempFile();
-  protected Preferences prefs;
+    private File lsFile = getTempFile();
+    @Mock
+    private ImageRegistry imageRegistry;
+    protected Preferences prefs;
 
-  @BeforeEach
-  protected void setUp() {
-    clearAllCaches();
-    if (lsFile.exists())
-      lsFile.delete();
-    lsFile = getTempFile();
-    environment = mock(LsRuntimeEnvironment.class);
-    InMemoryPreferenceStore store = new InMemoryPreferenceStore();
-    InMemorySecurePreferenceStore secureStore = new InMemorySecurePreferenceStore();
-    this.prefs = Preferences.getTestInstance(store, secureStore);
-    this.prefs.setSecureStorageReady(true);
-	PreferencesUtils.setPreferences(prefs);
-    this.prefs.setTest(true);
+    @BeforeEach
+    protected void setUp() {
+        clearAllCaches();
+        if (lsFile.exists())
+            lsFile.delete();
+        lsFile = getTempFile();
+        environment = mock(LsRuntimeEnvironment.class);
+        InMemoryPreferenceStore store = new InMemoryPreferenceStore();
+        InMemorySecurePreferenceStore secureStore = new InMemorySecurePreferenceStore();
+        this.prefs = Preferences.getTestInstance(store, secureStore);
+        this.prefs.setSecureStorageReady(true);
+        PreferencesUtils.setPreferences(prefs);
+        this.prefs.setTest(true);
 
-    when(environment.getArch()).thenReturn("amd64");
-    when(environment.getOs()).thenReturn("linux");
-    when(environment.getDownloadBinaryName()).thenReturn("snyk-ls_testVersion_linux_amd64");
-    proxyServiceMock = mock(IProxyService.class);
-    when(environment.getProxyService()).thenReturn(proxyServiceMock);
-  }
+        MockitoAnnotations.openMocks(this);
+//		when(imageRegistry.get(anyString())).thenReturn(mock(Image.class));
+        when(imageRegistry.getDescriptor(anyString())).thenReturn(mock(ImageDescriptor.class));
 
-  @AfterEach
-  protected void tearDown() {
-    lsFile.delete();
-    clearAllCaches();
-  }
-
-  protected File getTempFile() {
-    try {
-      File tempFile = File.createTempFile("ls-test", "tmp");
-      tempFile.deleteOnExit();
-      return tempFile;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+        when(environment.getArch()).thenReturn("amd64");
+        when(environment.getOs()).thenReturn("linux");
+        when(environment.getDownloadBinaryName()).thenReturn("snyk-ls_testVersion_linux_amd64");
+        proxyServiceMock = mock(IProxyService.class);
+        when(environment.getProxyService()).thenReturn(proxyServiceMock);
     }
-  }
+
+    @AfterEach
+    protected void tearDown() {
+        lsFile.delete();
+        clearAllCaches();
+    }
+
+    protected File getTempFile() {
+        try {
+            File tempFile = File.createTempFile("ls-test", "tmp");
+            tempFile.deleteOnExit();
+            return tempFile;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.ProgressParams;
 import org.eclipse.lsp4j.WorkDoneProgressBegin;
@@ -229,7 +230,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 		param.setStatus(SCAN_STATE_IN_PROGRESS);
 		param.setProduct(SCAN_PARAMS_CODE);
 		param.setFolderPath("a/b/c");
-		ProductTreeNode productNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
+		ProductTreeNode productNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY, mock(ImageDescriptor.class));
 		when(toolWindowMock.getProductNode(DISPLAYED_CODE_SECURITY, param.getFolderPath())).thenReturn(productNode);
 		pref.store(Preferences.ACTIVATE_SNYK_CODE_SECURITY, "true");
 		pref.store(Preferences.ACTIVATE_SNYK_CODE_QUALITY, "true");
@@ -448,12 +449,15 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 		var productNodes = new HashSet<ProductTreeNode>();
 		boolean notSnykCode = displayProduct != null;
 		if (notSnykCode) {
-			ProductTreeNode node = new ProductTreeNode(displayProduct);
+			ProductTreeNode node = new ProductTreeNode(displayProduct, mock(ImageDescriptor.class));
 			productNodes.add(node);
 			when(toolWindowMock.getProductNode(displayProduct, param.getFolderPath())).thenReturn(node);
 		} else {
-			ProductTreeNode codeSecurityProductNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
-			ProductTreeNode codeQualityProductNode = new ProductTreeNode(DISPLAYED_CODE_QUALITY);
+
+			ProductTreeNode codeSecurityProductNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY,
+					mock(ImageDescriptor.class));
+			ProductTreeNode codeQualityProductNode = new ProductTreeNode(DISPLAYED_CODE_QUALITY,
+					mock(ImageDescriptor.class));
 			productNodes.add(codeSecurityProductNode);
 			productNodes.add(codeQualityProductNode);
 			when(toolWindowMock.getProductNode(DISPLAYED_CODE_SECURITY, param.getFolderPath()))
@@ -557,7 +561,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 	@Test
 	void testGetTotal() throws IOException {
 		cut = new SnykExtendedLanguageClient();
-		ProductTreeNode productTreeNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
+		ProductTreeNode productTreeNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY, mock(ImageDescriptor.class));
 		SnykIssueCache issueCache = new SnykIssueCache(Path.of("a/b"));
 		var issues = new HashSet<Issue>();
 		var highIssue = Instancio.of(Issue.class).set(Select.field(Issue::additionalData), getSecurityIssue())

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -32,7 +32,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.ProgressParams;
 import org.eclipse.lsp4j.WorkDoneProgressBegin;
@@ -230,7 +229,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 		param.setStatus(SCAN_STATE_IN_PROGRESS);
 		param.setProduct(SCAN_PARAMS_CODE);
 		param.setFolderPath("a/b/c");
-		ProductTreeNode productNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY, mock(ImageDescriptor.class));
+		ProductTreeNode productNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
 		when(toolWindowMock.getProductNode(DISPLAYED_CODE_SECURITY, param.getFolderPath())).thenReturn(productNode);
 		pref.store(Preferences.ACTIVATE_SNYK_CODE_SECURITY, "true");
 		pref.store(Preferences.ACTIVATE_SNYK_CODE_QUALITY, "true");
@@ -449,15 +448,12 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 		var productNodes = new HashSet<ProductTreeNode>();
 		boolean notSnykCode = displayProduct != null;
 		if (notSnykCode) {
-			ProductTreeNode node = new ProductTreeNode(displayProduct, mock(ImageDescriptor.class));
+			ProductTreeNode node = new ProductTreeNode(displayProduct);
 			productNodes.add(node);
 			when(toolWindowMock.getProductNode(displayProduct, param.getFolderPath())).thenReturn(node);
 		} else {
-
-			ProductTreeNode codeSecurityProductNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY,
-					mock(ImageDescriptor.class));
-			ProductTreeNode codeQualityProductNode = new ProductTreeNode(DISPLAYED_CODE_QUALITY,
-					mock(ImageDescriptor.class));
+			ProductTreeNode codeSecurityProductNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
+			ProductTreeNode codeQualityProductNode = new ProductTreeNode(DISPLAYED_CODE_QUALITY);
 			productNodes.add(codeSecurityProductNode);
 			productNodes.add(codeQualityProductNode);
 			when(toolWindowMock.getProductNode(DISPLAYED_CODE_SECURITY, param.getFolderPath()))
@@ -561,7 +557,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 	@Test
 	void testGetTotal() throws IOException {
 		cut = new SnykExtendedLanguageClient();
-		ProductTreeNode productTreeNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY, mock(ImageDescriptor.class));
+		ProductTreeNode productTreeNode = new ProductTreeNode(DISPLAYED_CODE_SECURITY);
 		SnykIssueCache issueCache = new SnykIssueCache(Path.of("a/b"));
 		var issues = new HashSet<Issue>();
 		var highIssue = Instancio.of(Issue.class).set(Select.field(Issue::additionalData), getSecurityIssue())

--- a/update-site/category.xml
+++ b/update-site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_3.0.0.qualifier.jar" id="io.snyk.scanner" version="3.0.0.qualifier">
+  <feature url="features/io.snyk.scanner_3.1.0.qualifier.jar" id="io.snyk.scanner" version="3.1.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security">

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <packaging>eclipse-repository</packaging>
     <build>


### PR DESCRIPTION
### Description

- Using Eclipse ImageRegistry to cache images, and make sure they are disposed of correctly.
- fixed preference defaults and migration from secure storage to normal storage
- bumped Eclipse version to 3.1.0

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

No handle problem with >60000 issues.
![image](https://github.com/user-attachments/assets/61ca8e85-c111-4d8f-942d-b0f1d7cee084)

