### PR TITLE
fix: call updateSummary async

### DIFF
--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -436,8 +436,10 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 
 	@JsonNotification(value = LsConstants.SNYK_SCAN_SUMMARY)
 	public void updateSummaryPanel(SummaryPanelParams summary) {
-		openToolView();
-		this.toolView.updateSummary(summary.getSummary());
+		CompletableFuture.runAsync(() -> {
+			openToolView();
+			this.toolView.updateSummary(summary.getSummary());
+		});
 	}
 
 	@Override


### PR DESCRIPTION
### Description

UpdateSummary is called before ToolsView is initialized, causing a NullPointerException.

Fixed by using async.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
