### PR TITLE
fix: close image input stream

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/ResourceUtils.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/ResourceUtils.java
@@ -42,9 +42,9 @@ public class ResourceUtils {
 	}
 
 	private static byte[] getImageDataFromUrl(URL imageUrl) {
-		try {
-			ByteArrayOutputStream output = new ByteArrayOutputStream();
-			imageUrl.openStream().transferTo(output);
+		try (final var openStream = imageUrl.openStream()) {
+			ByteArrayOutputStream output = new ByteArrayOutputStream();			
+			openStream.transferTo(output);
 			return output.toByteArray();
 		} catch (Exception e) {
 			SnykLogger.logError(e);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/ResourceUtils.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/ResourceUtils.java
@@ -43,7 +43,7 @@ public class ResourceUtils {
 
 	private static byte[] getImageDataFromUrl(URL imageUrl) {
 		try (final var openStream = imageUrl.openStream()) {
-			ByteArrayOutputStream output = new ByteArrayOutputStream();			
+			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			openStream.transferTo(output);
 			return output.toByteArray();
 		} catch (Exception e) {


### PR DESCRIPTION
### Description

When loading images, put the input stream into an auto-closable block

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
