### PR TITLE
feat: Update Endpoint Description in Settings

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
@@ -50,7 +50,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 		addField(tokenField);
 
 		addField(new StringFieldEditor(Preferences.PATH_KEY, "Path:", 80, getFieldEditorParent()));
-		addField(new LabelFieldEditor("If you're using SSO(OAuth2), Custom Endpoint configuration is automatic.\n"
+		addField(new LabelFieldEditor("If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated.\n"
 				+ "Otherwise, for public regional instances, " + "see the docs: ", getFieldEditorParent()));
 		Link link = new Link(this.getFieldEditorParent(), SWT.NONE);
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
@@ -50,7 +50,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 		addField(tokenField);
 
 		addField(new StringFieldEditor(Preferences.PATH_KEY, "Path:", 80, getFieldEditorParent()));
-		addField(new LabelFieldEditor("If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated.\n"
+		addField(new LabelFieldEditor("If you're using SSO with Snyk and OAuth2, the custom endpoint configuration is automatically populated.\n"
 				+ "Otherwise, for public regional instances, " + "see the docs: ", getFieldEditorParent()));
 		Link link = new Link(this.getFieldEditorParent(), SWT.NONE);
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
@@ -9,7 +9,10 @@ import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -37,8 +40,8 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 		setPreferenceStore(prefs.getInsecureStore());
 
 		// token field editor is configured to use a secure store
-		TokenFieldEditor tokenField = new TokenFieldEditor(prefs, Preferences.AUTH_TOKEN_KEY,
-				"Token:", getFieldEditorParent());
+		TokenFieldEditor tokenField = new TokenFieldEditor(prefs, Preferences.AUTH_TOKEN_KEY, "Token:",
+				getFieldEditorParent());
 
 		final var useTokenAuth = new BooleanFieldEditor(Preferences.USE_TOKEN_AUTH,
 				"Use token authentication. It is recommended to keep this turned off, as the default OAuth2 authentication is more secure.",
@@ -47,6 +50,16 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 		addField(tokenField);
 
 		addField(new StringFieldEditor(Preferences.PATH_KEY, "Path:", 80, getFieldEditorParent()));
+		addField(new LabelFieldEditor("If you're using SSO(OAuth2), Custom Endpoint configuration is automatic.\n"
+				+ "Otherwise, for public regional instances, " + "see the docs: ", getFieldEditorParent()));
+		Link link = new Link(this.getFieldEditorParent(), SWT.NONE);
+
+		link.setText("<a>https://docs.snyk.io/working-with-snyk</a>");
+		link.addListener(SWT.Selection, event -> Program.launch(
+				"https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions"));
+
+		addField(new LabelFieldEditor("For private instances, contact your team or account manager.\n",
+				getFieldEditorParent()));
 		addField(new StringFieldEditor(Preferences.ENDPOINT_KEY, "Custom Endpoint:", 80, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(Preferences.INSECURE_KEY, "Allow unknown certificate authorities",
 				getFieldEditorParent()));
@@ -124,12 +137,12 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 	public boolean performOk() {
 		boolean superOK = super.performOk();
 		disableSnykCodeIfOrgDisabled();
-        CompletableFuture.runAsync(() -> {
-            SnykExtendedLanguageClient lc = SnykExtendedLanguageClient.getInstance();
+		CompletableFuture.runAsync(() -> {
+			SnykExtendedLanguageClient lc = SnykExtendedLanguageClient.getInstance();
 
 			lc.updateConfiguration();
-            lc.refreshFeatureFlags();
-        });
+			lc.refreshFeatureFlags();
+		});
 		return superOK;
 	}
 
@@ -152,7 +165,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 
 				@Override
 				public void run() {
-						checkBoxValue = snykCodeSecurityCheckbox != null && snykCodeSecurityCheckbox.getBooleanValue();
+					checkBoxValue = snykCodeSecurityCheckbox != null && snykCodeSecurityCheckbox.getBooleanValue();
 					if (checkBoxValue && !enabled) {
 						snykCodeSecurityCheckbox
 								.setLabelText(snykCodeSecurityCheckbox.getLabelText() + " (" + message + ")");


### PR DESCRIPTION
### Description

In IDEs, you can configure a custom endpoint in order to target a custom region (e.g EU). The current description for this option is "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. https://api.eu.snyk.io/.". With the recent platform changes, on OAuth using SSO, we automatically redirect to the right instance and that field does not need to be configured anymore.

Update
If you're using SSO (OAuth2), API endpoint configuration is automatic. Otherwise, for public regional instances, see the docs. For private instances, contact your team or account manager.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
