### PR TITLE
fix: remove blank template replacements [IDE-1050]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -130,10 +130,12 @@ public class BaseHtmlProvider {
 		htmlStyled = htmlStyled.replace("var(--horizontal-border-color)",
 				getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_OUTER_KEYLINE_COLOR", "#CCCCCC"));
 
-		htmlStyled = htmlStyled.replace("${headerEnd}", "");
+		// Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+		// and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+		htmlStyled = htmlStyled.replace("${headerEnd}", " ");
 		htmlStyled = htmlStyled.replace("${nonce}", nonce);
 		htmlStyled = htmlStyled.replaceAll("ideNonce", nonce);
-		htmlStyled = htmlStyled.replace("${ideScript}", "");
+		htmlStyled = htmlStyled.replace("${ideScript}", " ");
 
 		return htmlStyled;
 	}


### PR DESCRIPTION
### Description

This PR, aims to fix a potential cross-site scripting (XSS) vulnerability in the HTML reports. 
By using a space for replacements, the attacker cannot use a bypass using "${nonce${resolvesToEmpty}}".

Checklist

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
