### PR TITLE
fix: workspace folder scans

### DIFF
--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -204,7 +204,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 				try {
 					if (projectPath != null) {
 						if (languageServerConfigReceived.contains(projectPath)) {
-							executeCommand(LsConstants.COMMAND_WORKSPACE_FOLDER_SCAN, List.of(projectPath));
+							executeCommand(LsConstants.COMMAND_WORKSPACE_FOLDER_SCAN, List.of(projectPath.toString()));
 						}
 						return;
 					}


### PR DESCRIPTION
### Description

Broken when we switched to `Path`s instead of `String`s: [here](https://github.com/snyk/snyk-eclipse-plugin/commit/34394a3385fb2f7879185c600753cbff6c2a94b9#diff-dc3b50a74bccca485397b19463e5aa247bbca019effc5fe7b7f27cde8752a6f7R181)

### Checklist

- [ ] Tests added and all succeed
 - No.
- [x] Linted
- [ ] CHANGELOG.md updated
 - No, because I don't really know what the feature is that I've fixed.
- [ ] README.md updated, if user-facing
 - N/A.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
