### PR TITLE
feat(IDE-1652): add inbound $/snyk.configuration handler and outbound updater (2/3)

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/ExecuteCommandBridge.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/ExecuteCommandBridge.java
@@ -6,6 +6,8 @@ import io.snyk.eclipse.plugin.preferences.AuthConstants;
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.languageserver.CommandHandler;
+import io.snyk.languageserver.LsKey;
+import io.snyk.languageserver.LsSettingsRegistry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -111,9 +113,18 @@ public class ExecuteCommandBridge {
     String endpoint = args.get(1) != null ? String.valueOf(args.get(1)) : "";
     String insecure = String.valueOf(args.get(2));
     Preferences prefs = Preferences.getInstance();
-    prefs.store(Preferences.AUTHENTICATION_METHOD, authMethod);
-    prefs.store(Preferences.ENDPOINT_KEY, endpoint);
-    prefs.store(Preferences.INSECURE_KEY, insecure);
+    storeAndMarkIfChanged(prefs, LsKey.AUTHENTICATION_METHOD, authMethod);
+    storeAndMarkIfChanged(prefs, LsKey.ENDPOINT, endpoint);
+    storeAndMarkIfChanged(prefs, LsKey.INSECURE, insecure);
+    prefs.flushExplicitChanges();
+  }
+
+  private static void storeAndMarkIfChanged(Preferences prefs, LsKey lsKey, String value) {
+    LsSettingsRegistry.Entry entry = LsSettingsRegistry.ENTRIES.get(lsKey);
+    prefs.store(entry.prefKey, value);
+    if (!value.equals(entry.outboundDefault)) {
+      prefs.markExplicitlyChangedNoFlush(entry.prefKey);
+    }
   }
 
   private static void registerBridgeFunction(Browser browser) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
@@ -129,7 +129,7 @@ public class Preferences {
 		// Defaults for LS-backed keys driven from registry — single source of truth.
 		// Skips: fixed entries (no prefKey), AUTH_TOKEN_KEY (encrypted, not in insecureStore), CLI_PATH (computed below).
 		for (LsSettingsRegistry.Entry entry : LsSettingsRegistry.ENTRIES.values()) {
-			if (entry.prefKey == null || AUTH_TOKEN_KEY.equals(entry.prefKey) || CLI_PATH.equals(entry.prefKey)) {
+			if (entry.prefKey == null || entry.encrypted || CLI_PATH.equals(entry.prefKey)) {
 				continue;
 			}
 			insecureStore.setDefault(entry.prefKey, entry.outboundDefault);
@@ -142,6 +142,7 @@ public class Preferences {
 		insecureStore.setDefault(ANALYTICS_PLUGIN_INSTALLED_SENT, FALSE);
 		insecureStore.setDefault(DEVICE_ID, UUID.randomUUID().toString());
 		insecureStore.setDefault(USE_LS_HTML_CONFIG_DIALOG, TRUE);
+		// TODO: move to LsSettingsRegistry once Entry supports Supplier<String> defaults (CLI_PATH is runtime-computed)
 		insecureStore.setDefault(CLI_PATH, getDefaultCliPath());
 
 		String savedExplicitChanges = insecure.get(EXPLICIT_CHANGES_KEY, "");
@@ -197,6 +198,21 @@ public class Preferences {
 		if (getBooleanPref(USE_TOKEN_AUTH)) {
 			store(AUTHENTICATION_METHOD, AuthConstants.AUTH_API_TOKEN);
 			store(USE_TOKEN_AUTH, FALSE);
+		}
+
+		// One-time upgrade migration: seed explicitChanges for any pref already
+		// customized on disk, so the first outbound sync sends changed=true for them.
+		if (explicitChanges.isEmpty()) {
+			for (LsSettingsRegistry.Entry entry : LsSettingsRegistry.ENTRIES.values()) {
+				if (entry.prefKey == null || entry.encrypted) {
+					continue;
+				}
+				String stored = insecurePreferences.get(entry.prefKey, null);
+				if (stored != null && !stored.equals(entry.outboundDefault)) {
+					explicitChanges.add(entry.prefKey);
+				}
+			}
+			persistExplicitChanges();
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -28,6 +29,7 @@ import io.snyk.eclipse.plugin.Activator;
 import io.snyk.eclipse.plugin.EnvironmentConstants;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.languageserver.LsRuntimeEnvironment;
+import io.snyk.languageserver.LsSettingsRegistry;
 
 public class Preferences {
 	private static final String FALSE = "false";
@@ -85,6 +87,7 @@ public class Preferences {
 	public static final String DEVICE_ID = "deviceId";
 	public static final String RELEASE_CHANNEL = "releaseChannel";
 	public static final String USE_LS_HTML_CONFIG_DIALOG = "useLsHtmlConfigDialog";
+	public static final String EXPLICIT_CHANGES_KEY = "explicitChanges";
 
 	private static final Set<String> encryptedPreferenceKeys = Set.of(AUTH_TOKEN_KEY);
 	private final IEclipsePreferences insecurePreferences;
@@ -93,6 +96,7 @@ public class Preferences {
 	private IPreferenceStore secureStore;
 	private boolean secureStorageReady;
 	private Map<String, String> prefSaveMap = new ConcurrentHashMap<>();
+	private final Set<String> explicitChanges = ConcurrentHashMap.newKeySet();
 	private static Function<String, String> envProvider = System::getenv;
 
 	public static synchronized Preferences getInstance() {
@@ -122,32 +126,33 @@ public class Preferences {
 			waitForSecureStorage();
 		});
 
-		insecureStore.setDefault(ACTIVATE_SNYK_CODE_SECURITY, FALSE);
-		insecureStore.setDefault(ACTIVATE_SNYK_OPEN_SOURCE, TRUE);
-		insecureStore.setDefault(ACTIVATE_SNYK_IAC, TRUE);
-		insecureStore.setDefault(FILTER_SHOW_CRITICAL, TRUE);
-		insecureStore.setDefault(FILTER_SHOW_HIGH, TRUE);
-		insecureStore.setDefault(FILTER_SHOW_MEDIUM, TRUE);
-		insecureStore.setDefault(FILTER_SHOW_LOW, TRUE);
-		insecureStore.setDefault(ENABLE_DELTA, FALSE);
-		insecureStore.setDefault(RISK_SCORE_THRESHOLD, "0");
-		insecureStore.setDefault(FILTER_IGNORES_SHOW_OPEN_ISSUES, TRUE);
-		insecureStore.setDefault(FILTER_IGNORES_SHOW_IGNORED_ISSUES, FALSE);
+		// Defaults for LS-backed keys driven from registry — single source of truth.
+		// Skips: fixed entries (no prefKey), AUTH_TOKEN_KEY (encrypted, not in insecureStore), CLI_PATH (computed below).
+		for (LsSettingsRegistry.Entry entry : LsSettingsRegistry.ENTRIES.values()) {
+			if (entry.prefKey == null || AUTH_TOKEN_KEY.equals(entry.prefKey) || CLI_PATH.equals(entry.prefKey)) {
+				continue;
+			}
+			insecureStore.setDefault(entry.prefKey, entry.outboundDefault);
+		}
+		// Non-LS keys with no registry entry.
 		insecureStore.setDefault(FILTER_SHOW_ONLY_FIXABLE, FALSE);
-		insecureStore.setDefault(MANAGE_BINARIES_AUTOMATICALLY, TRUE);
 		insecureStore.setDefault(LSP_VERSION, "1");
 		insecureStore.setDefault(IS_GLOBAL_IGNORES_FEATURE_ENABLED, FALSE);
-		insecureStore.setDefault(CLI_BASE_URL, "https://downloads.snyk.io");
-		insecureStore.setDefault(SCANNING_MODE_AUTOMATIC, TRUE);
 		insecureStore.setDefault(USE_TOKEN_AUTH, FALSE);
-		insecureStore.setDefault(AUTHENTICATION_METHOD, AuthConstants.AUTH_OAUTH2);
 		insecureStore.setDefault(ANALYTICS_PLUGIN_INSTALLED_SENT, FALSE);
 		insecureStore.setDefault(DEVICE_ID, UUID.randomUUID().toString());
-		insecureStore.setDefault(RELEASE_CHANNEL, "stable");
 		insecureStore.setDefault(USE_LS_HTML_CONFIG_DIALOG, TRUE);
 		insecureStore.setDefault(CLI_PATH, getDefaultCliPath());
-		insecureStore.setDefault(ENDPOINT_KEY, DEFAULT_ENDPOINT);
-		insecureStore.setDefault(ORGANIZATION_KEY, "");
+
+		String savedExplicitChanges = insecure.get(EXPLICIT_CHANGES_KEY, "");
+		if (savedExplicitChanges != null && !savedExplicitChanges.isEmpty()) {
+			for (String key : savedExplicitChanges.split(",")) {
+				String trimmed = key.trim();
+				if (!trimmed.isEmpty()) {
+					explicitChanges.add(trimmed);
+				}
+			}
+		}
 
 		var endpoint = getEnvironmentVariable(ENV_SNYK_API, "");
 		if (endpoint != null && !endpoint.isBlank()) {
@@ -374,5 +379,66 @@ public class Preferences {
 			return false;
 		}
 		return true;
+	}
+
+	public final void storeAndTrackChange(String key, String value) {
+		if (key == null || value == null) {
+			return;
+		}
+		String oldValue = getPref(key);
+		store(key, value);
+		if (!Objects.equals(oldValue, value)) {
+			markExplicitlyChanged(key);
+		}
+	}
+
+	public void markExplicitlyChanged(String key) {
+		if (key == null) {
+			return;
+		}
+		explicitChanges.add(key);
+		persistExplicitChanges();
+	}
+
+	public void markExplicitlyChangedNoFlush(String key) {
+		if (key == null) {
+			return;
+		}
+		explicitChanges.add(key);
+	}
+
+	public void clearExplicitlyChangedNoFlush(String key) {
+		if (key == null) {
+			return;
+		}
+		explicitChanges.remove(key);
+	}
+
+	public void flushExplicitChanges() {
+		persistExplicitChanges();
+	}
+
+	public boolean isExplicitlyChanged(String key) {
+		if (key == null) {
+			return false;
+		}
+		return explicitChanges.contains(key);
+	}
+
+	public void clearExplicitlyChanged(String key) {
+		if (key == null) {
+			return;
+		}
+		explicitChanges.remove(key);
+		persistExplicitChanges();
+	}
+
+	private void persistExplicitChanges() {
+		insecurePreferences.put(EXPLICIT_CHANGES_KEY, String.join(",", explicitChanges));
+		try {
+			insecurePreferences.flush();
+		} catch (org.osgi.service.prefs.BackingStoreException e) {
+			SnykLogger.logError(e);
+		}
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/PreferencesPage.java
@@ -1,6 +1,9 @@
 package io.snyk.eclipse.plugin.preferences;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -222,7 +225,26 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
 
 	@Override
 	public boolean performOk() {
+		Preferences preferences = Preferences.getInstance();
+		// Snapshot old values before field editors store directly to IPreferenceStore
+		String[] trackedKeys = io.snyk.languageserver.LsSettingsRegistry.ENTRIES.values().stream()
+				.filter(e -> e.prefKey != null)
+				.map(e -> e.prefKey)
+				.toArray(String[]::new);
+		Map<String, String> oldValues = new HashMap<>();
+		for (String key : trackedKeys) {
+			oldValues.put(key, preferences.getPref(key, ""));
+		}
+
 		boolean superOK = super.performOk();
+
+		for (String key : trackedKeys) {
+			String newValue = preferences.getPref(key, "");
+			if (!Objects.equals(oldValues.get(key), newValue)) {
+				preferences.markExplicitlyChanged(key);
+			}
+		}
+
 		CompletableFuture.runAsync(() -> {
 			SnykExtendedLanguageClient lc = SnykExtendedLanguageClient.getInstance();
 			lc.updateConfiguration();

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/TokenFieldEditor.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/TokenFieldEditor.java
@@ -1,5 +1,7 @@
 package io.snyk.eclipse.plugin.preferences;
 
+import java.util.Objects;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
@@ -14,13 +16,21 @@ public class TokenFieldEditor extends StringFieldEditor {
 		super.setPreferenceStore(preferences.getSecureStore());
 		this.getTextControl().setEchoChar('*');
 	}
-	
+
 	@Override
 	protected final  Text getTextControl() {
 		return super.getTextControl();
 	}
 
-
+	@Override
+	protected void doStore() {
+		String oldValue = getPreferenceStore().getString(getPreferenceName());
+		super.doStore();
+		String newValue = getStringValue();
+		if (!Objects.equals(oldValue, newValue)) {
+			preferences.markExplicitlyChanged(Preferences.AUTH_TOKEN_KEY);
+		}
+	}
 
 	public void emptyTextfield() {
 		setStringValue("");

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/FolderConfigSettings.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/FolderConfigSettings.java
@@ -32,7 +32,7 @@ public class FolderConfigSettings {
 		instance = i;
 	}
 
-	public void addFolderConfig(LspFolderConfig folderConfig) {
+	public synchronized void addFolderConfig(LspFolderConfig folderConfig) {
 		if (folderConfig.getFolderPath() == null) {
 			return;
 		}
@@ -90,7 +90,7 @@ public class FolderConfigSettings {
 		return configs.containsKey(key);
 	}
 
-	public void updateFolderConfig(String folderPath, LspFolderConfig config) {
+	public synchronized void updateFolderConfig(String folderPath, LspFolderConfig config) {
 		if (folderPath == null) {
 			return;
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/FolderConfigSettings.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/FolderConfigSettings.java
@@ -1,0 +1,196 @@
+package io.snyk.eclipse.plugin.properties;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import io.snyk.eclipse.plugin.utils.SnykLogger;
+import io.snyk.languageserver.LsFolderSettingsKeys;
+import io.snyk.languageserver.protocolextension.messageObjects.ConfigSetting;
+import io.snyk.languageserver.protocolextension.messageObjects.LspFolderConfig;
+
+public class FolderConfigSettings {
+
+	private static FolderConfigSettings instance;
+
+	private final Map<String, LspFolderConfig> configs = new ConcurrentHashMap<>();
+
+	public static synchronized FolderConfigSettings getInstance() {
+		if (instance == null) {
+			instance = new FolderConfigSettings();
+		}
+		return instance;
+	}
+
+	public static synchronized void setInstance(FolderConfigSettings i) {
+		instance = i;
+	}
+
+	public void addFolderConfig(LspFolderConfig folderConfig) {
+		if (folderConfig.getFolderPath() == null) {
+			return;
+		}
+		String key = normalizePath(folderConfig.getFolderPath());
+		configs.put(key, folderConfig);
+	}
+
+	/**
+	 * Replaces the full folder config state with the incoming snapshot from the LS.
+	 * LS protocol v25 guarantees {@code $/snyk.configuration} carries all folders — incoming list
+	 * is authoritative; folders absent from it are removed.
+	 */
+	public synchronized void addAll(List<LspFolderConfig> folderConfigs) {
+		// Collect paths present in the incoming list; remove folders no longer reported by LS.
+		Set<String> incomingKeys = new HashSet<>();
+		for (LspFolderConfig incoming : folderConfigs) {
+			if (incoming.getFolderPath() == null) {
+				continue;
+			}
+			String key = normalizePath(incoming.getFolderPath());
+			incomingKeys.add(key);
+			configs.put(key, incoming);
+		}
+		configs.keySet().retainAll(incomingKeys);
+	}
+
+	public LspFolderConfig getFolderConfig(String folderPath) {
+		if (folderPath == null) {
+			return createEmptyConfig(null);
+		}
+		String key = normalizePath(folderPath);
+		LspFolderConfig config = configs.get(key);
+		if (config == null) {
+			return createEmptyConfig(folderPath);
+		}
+		return config;
+	}
+
+	private LspFolderConfig createEmptyConfig(String folderPath) {
+		LspFolderConfig config = new LspFolderConfig();
+		config.setFolderPath(folderPath);
+		config.setSettings(new java.util.HashMap<>());
+		return config;
+	}
+
+	public synchronized List<LspFolderConfig> getAll() {
+		return new ArrayList<>(configs.values());
+	}
+
+	public boolean isConfigured(String folderPath) {
+		if (folderPath == null) {
+			return false;
+		}
+		String key = normalizePath(folderPath);
+		return configs.containsKey(key);
+	}
+
+	public void updateFolderConfig(String folderPath, LspFolderConfig config) {
+		if (folderPath == null) {
+			return;
+		}
+		String key = normalizePath(folderPath);
+		configs.put(key, config);
+	}
+
+	public synchronized void computeFolderConfig(String folderPath, Function<LspFolderConfig, LspFolderConfig> updater) {
+		if (folderPath == null) {
+			return;
+		}
+		String key = normalizePath(folderPath);
+		LspFolderConfig existing = configs.get(key);
+		if (existing == null) {
+			existing = createEmptyConfig(folderPath);
+		}
+		configs.put(key, updater.apply(existing));
+	}
+
+	public String getBaseBranch(String path) {
+		return getStringSettingValue(path, LsFolderSettingsKeys.BASE_BRANCH);
+	}
+
+	public String getPreferredOrg(String path) {
+		return getStringSettingValue(path, LsFolderSettingsKeys.PREFERRED_ORG);
+	}
+
+	public List<String> getLocalBranches(String path) {
+		ConfigSetting setting = getSetting(path, LsFolderSettingsKeys.LOCAL_BRANCHES);
+		if (setting == null || setting.getValue() == null) {
+			return Collections.emptyList();
+		}
+		Object value = setting.getValue();
+		if (value instanceof List<?> rawList) {
+			List<String> result = new ArrayList<>();
+			for (Object item : rawList) {
+				result.add(String.valueOf(item));
+			}
+			return result;
+		}
+		return Collections.emptyList();
+	}
+
+	public List<String> getAdditionalParameters(String path) {
+		ConfigSetting setting = getSetting(path, LsFolderSettingsKeys.ADDITIONAL_PARAMETERS);
+		if (setting == null || setting.getValue() == null) {
+			return Collections.emptyList();
+		}
+		Object value = setting.getValue();
+		if (value instanceof List<?> rawList) {
+			List<String> result = new ArrayList<>();
+			for (Object item : rawList) {
+				result.add(String.valueOf(item));
+			}
+			return result;
+		}
+		if (value instanceof String str && !str.isEmpty()) {
+			return List.of(str);
+		}
+		return Collections.emptyList();
+	}
+
+	public String getReferenceFolderPath(String path) {
+		return getStringSettingValue(path, LsFolderSettingsKeys.REFERENCE_FOLDER_PATH);
+	}
+
+	public boolean isOrgSetByUser(String path) {
+		ConfigSetting setting = getSetting(path, LsFolderSettingsKeys.ORG_SET_BY_USER);
+		if (setting == null || setting.getValue() == null) {
+			return false;
+		}
+		Object value = setting.getValue();
+		if (value instanceof Boolean) {
+			return (Boolean) value;
+		}
+		return Boolean.parseBoolean(String.valueOf(value));
+	}
+
+	public String getAutoDeterminedOrg(String path) {
+		return getStringSettingValue(path, LsFolderSettingsKeys.AUTO_DETERMINED_ORG);
+	}
+
+	private ConfigSetting getSetting(String path, String key) {
+		LspFolderConfig config = getFolderConfig(path);
+		Map<String, ConfigSetting> settings = config.getSettings();
+		if (settings == null) {
+			return null;
+		}
+		return settings.get(key);
+	}
+
+	private String getStringSettingValue(String path, String key) {
+		ConfigSetting setting = getSetting(path, key);
+		if (setting == null || setting.getValue() == null) {
+			return "";
+		}
+		return String.valueOf(setting.getValue());
+	}
+
+	private String normalizePath(String path) {
+		return Paths.get(path).normalize().toAbsolutePath().toString();
+	}
+}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/properties/NativeProjectPropertyPage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/properties/NativeProjectPropertyPage.java
@@ -2,6 +2,7 @@ package io.snyk.eclipse.plugin.properties;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IProject;
@@ -25,8 +26,8 @@ import io.snyk.eclipse.plugin.Activator;
 import io.snyk.eclipse.plugin.preferences.LabelFieldEditor;
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.ResourceUtils;
+import io.snyk.languageserver.LsFolderSettingsKeys;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfig;
 
 /**
  * Native project-specific settings page for Snyk (used when HTML settings are disabled)
@@ -52,15 +53,19 @@ public class NativeProjectPropertyPage extends FieldEditorPreferencePage impleme
 		@Override
 		protected void valueChanged(boolean oldValue, boolean newValue) {
 			super.valueChanged(oldValue, newValue);
-			var folderConfig = FolderConfigs.getInstance().getFolderConfig(projectPath);
-			if (folderConfig != null) {
-				folderConfig.setOrgSetByUser(!newValue);
+			String pathStr = projectPath.toString();
+			FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
+			if (configSettings.isConfigured(pathStr)) {
 				projectOrg.setEnabled(!newValue, getFieldEditorParent());
 
 				if (newValue) {
-					folderConfig.setPreferredOrg("");
-					updateProjectOrg(folderConfig);
+					configSettings.computeFolderConfig(pathStr, config ->
+							config.withSettingIfChanged(LsFolderSettingsKeys.ORG_SET_BY_USER, !newValue)
+									.withSettingIfChanged(LsFolderSettingsKeys.PREFERRED_ORG, ""));
+					updateProjectOrg(pathStr);
 				} else {
+					configSettings.computeFolderConfig(pathStr, config ->
+							config.withSettingIfChanged(LsFolderSettingsKeys.ORG_SET_BY_USER, !newValue));
 					projectOrg.setStringValue("");
 				}
 			}
@@ -151,8 +156,10 @@ public class NativeProjectPropertyPage extends FieldEditorPreferencePage impleme
 
 	private void populate() {
 		Composite parent = getFieldEditorParent();
+		String pathStr = projectPath.toString();
+		FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
 
-		if (!FolderConfigs.LanguageServerConfigReceived.contains(projectPath)) {
+		if (!configSettings.isConfigured(pathStr)) {
 			additionalParamsEditor.setEnabled(false, parent);
 			autoDetectOrgCheckbox.setEnabled(false, parent);
 			projectOrg.setEnabled(false, parent);
@@ -167,45 +174,42 @@ public class NativeProjectPropertyPage extends FieldEditorPreferencePage impleme
 			preferenceStore.setDefault(SNYK_ORGANIZATION, "");
 			preferenceStore.setValue(SNYK_ORGANIZATION, "");
 		} else {
-			var folderConfig = FolderConfigs.getInstance().getFolderConfig(projectPath);
 			additionalParamsEditor.setEnabled(true, parent);
 
-			final var addParams = folderConfig.getAdditionalParameters() != null
-					? String.join(" ", folderConfig.getAdditionalParameters())
-					: "";
+			final var addParamsList = configSettings.getAdditionalParameters(pathStr);
+			final var addParams = String.join(" ", addParamsList);
 			preferenceStore.setDefault(SNYK_ADDITIONAL_PARAMETERS, addParams);
 			preferenceStore.setValue(SNYK_ADDITIONAL_PARAMETERS, addParams);
 			additionalParamsEditor.setStringValue(addParams);
 
 			autoDetectOrgCheckbox.setEnabled(true, parent);
-			boolean autoDetect = !folderConfig.isOrgSetByUser();
+			boolean autoDetect = !configSettings.isOrgSetByUser(pathStr);
 			preferenceStore.setDefault(SNYK_AUTO_SELECT_ORG, autoDetect);
 			preferenceStore.setValue(SNYK_AUTO_SELECT_ORG, autoDetect);
 			autoDetectOrgCheckbox.load();
 
-			updateProjectOrg(folderConfig);
+			updateProjectOrg(pathStr);
 		}
 	}
 
-	private void updateProjectOrg(FolderConfig folderConfig) {
+	private void updateProjectOrg(String pathStr) {
 		Composite parent = getFieldEditorParent();
+		FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
 
-		if (folderConfig == null) {
+		if (!configSettings.isConfigured(pathStr)) {
 			projectOrg.setEnabled(false, parent);
 			projectOrg.setStringValue("");
 			return;
 		}
 
-		boolean autoDetect = !folderConfig.isOrgSetByUser();
+		boolean autoDetect = !configSettings.isOrgSetByUser(pathStr);
 
 		String displayOrg;
 		if (autoDetect) {
-			displayOrg = folderConfig.getAutoDeterminedOrg() != null ? folderConfig.getAutoDeterminedOrg() : "";
+			displayOrg = configSettings.getAutoDeterminedOrg(pathStr);
 		} else {
-			displayOrg = folderConfig.getPreferredOrg() != null ? folderConfig.getPreferredOrg() : "";
+			displayOrg = configSettings.getPreferredOrg(pathStr);
 		}
-
-		displayOrg = displayOrg != null ? displayOrg : "";
 
 		preferenceStore.setDefault(SNYK_ORGANIZATION, displayOrg);
 		preferenceStore.setValue(SNYK_ORGANIZATION, displayOrg);
@@ -241,32 +245,36 @@ public class NativeProjectPropertyPage extends FieldEditorPreferencePage impleme
 
 		var retValue = super.performOk();
 
-		if (!FolderConfigs.LanguageServerConfigReceived.contains(projectPath)) {
+		String pathStr = projectPath.toString();
+		FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
+
+		if (!configSettings.isConfigured(pathStr)) {
 			return retValue;
 		}
 
-		final var addParams = this.additionalParamsEditor.getStringValue() != null
-				? this.additionalParamsEditor.getStringValue().split(" ")
-				: new String[0];
+		final var addParamsStr = this.additionalParamsEditor.getStringValue() != null
+				? this.additionalParamsEditor.getStringValue()
+				: "";
+		final List<String> addParams = addParamsStr.isEmpty()
+				? List.of()
+				: Arrays.asList(addParamsStr.split("\\s+"));
 
-		var folderConfig = FolderConfigs.getInstance().getFolderConfig(projectPath);
-		if (folderConfig == null) {
-			return retValue;
-		}
+		configSettings.computeFolderConfig(pathStr, config -> {
+			config = config.withSettingIfChanged(LsFolderSettingsKeys.ADDITIONAL_PARAMETERS, addParams);
 
-		folderConfig.setAdditionalParameters(Arrays.asList(addParams));
+			if (autoDetect) {
+				config = config.withSettingIfChanged(LsFolderSettingsKeys.ORG_SET_BY_USER, false);
+			} else {
+				config = config.withSettingIfChanged(LsFolderSettingsKeys.ORG_SET_BY_USER, true);
+				String projectOrgValue = this.projectOrg.getStringValue();
+				config = config.withSettingIfChanged(LsFolderSettingsKeys.PREFERRED_ORG,
+						projectOrgValue != null ? projectOrgValue.trim() : "");
+			}
 
-		if (autoDetect) {
-			folderConfig.setOrgSetByUser(false);
-		} else {
-			folderConfig.setOrgSetByUser(true);
-			String projectOrgValue = this.projectOrg.getStringValue();
-			folderConfig.setPreferredOrg(projectOrgValue != null ? projectOrgValue.trim() : "");
-		}
+			return config;
+		});
+		updateProjectOrg(pathStr);
 
-		updateProjectOrg(folderConfig);
-
-		FolderConfigs.getInstance().addFolderConfig(folderConfig);
 		CompletableFuture.runAsync(() -> {
 			SnykExtendedLanguageClient.getInstance().updateConfiguration();
 		});

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ReferenceChooserDialog.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/ReferenceChooserDialog.java
@@ -18,21 +18,19 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
 import io.snyk.eclipse.plugin.preferences.Preferences;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.eclipse.plugin.wizards.SWTWidgetHelper;
+import io.snyk.languageserver.LsFolderSettingsKeys;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfig;
 
 public class ReferenceChooserDialog extends TitleAreaDialog {
 	private Path projectPath;
-	private FolderConfig folderConfig;
 	private Combo branches;
 	private Text folderText;
 
 	public ReferenceChooserDialog(Shell parentShell, Path projectPath) {
 		super(parentShell);
 		this.projectPath = projectPath;
-		this.folderConfig = FolderConfigs.getInstance().getFolderConfig(projectPath);
 	}
 
 	@Override
@@ -52,13 +50,16 @@ public class ReferenceChooserDialog extends TitleAreaDialog {
 		gridLayout.marginLeft = 5;
 		gridLayout.marginRight = 5;
 		panel.setLayout(gridLayout);
+		String pathStr = projectPath.toString();
+		FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
+
 		var group = SWTWidgetHelper.createGroup(panel, "Reference branch for " + projectPath.getFileName(), 1,
 				GridData.FILL_HORIZONTAL);
-		final var localBranches = folderConfig.getLocalBranches().toArray(new String[0]);
+		final var localBranches = configSettings.getLocalBranches(pathStr).toArray(new String[0]);
 		branches = new Combo(group, SWT.DROP_DOWN);
 		branches.setItems(localBranches);
 		branches.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-		branches.setText(folderConfig.getBaseBranch());
+		branches.setText(configSettings.getBaseBranch(pathStr));
 		branches.addModifyListener(new ModifyListener() {
 			@Override
 			public void modifyText(ModifyEvent e) {
@@ -70,7 +71,7 @@ public class ReferenceChooserDialog extends TitleAreaDialog {
 				GridData.FILL_HORIZONTAL);
 		folderText = new Text(group, SWT.BORDER);
 		folderText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		folderText.setText(folderConfig.getReferenceFolderPath());
+		folderText.setText(configSettings.getReferenceFolderPath(pathStr));
 		Button browseButton = new Button(group, SWT.PUSH);
 		browseButton.setText("Browse...");
 
@@ -98,9 +99,11 @@ public class ReferenceChooserDialog extends TitleAreaDialog {
 		final var referenceBranch = branches.getText();
 		final var referenceFolder = folderText.getText();
 
-		folderConfig.setBaseBranch(referenceBranch);
-		folderConfig.setReferenceFolderPath(referenceFolder);
-		FolderConfigs.getInstance().addFolderConfig(folderConfig);
+		String pathStr = projectPath.toString();
+		FolderConfigSettings.getInstance().computeFolderConfig(pathStr, config ->
+				config.withSettingIfChanged(LsFolderSettingsKeys.BASE_BRANCH, referenceBranch)
+						.withSettingIfChanged(LsFolderSettingsKeys.REFERENCE_FOLDER_PATH, referenceFolder));
+
 		CompletableFuture.runAsync(() -> {
 			final var lc = SnykExtendedLanguageClient.getInstance();
 			lc.updateConfiguration();

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -45,7 +45,7 @@ import org.eclipse.ui.menus.CommandContributionItemParameter;
 import org.eclipse.ui.part.ViewPart;
 
 import io.snyk.eclipse.plugin.preferences.Preferences;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.eclipse.plugin.utils.ResourceUtils;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.eclipse.plugin.views.snyktoolview.providers.TreeContentProvider;
@@ -460,9 +460,10 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	}
 
 	private void setReferenceText(ContentRootNode contentNode) {
-		var folderConfig = FolderConfigs.getInstance().getFolderConfig(contentNode.getPath());
-		String referenceFolder = folderConfig.getReferenceFolderPath();
-		String baseBranch = folderConfig.getBaseBranch();
+		String pathStr = contentNode.getPath().toString();
+		FolderConfigSettings configSettings = FolderConfigSettings.getInstance();
+		String referenceFolder = configSettings.getReferenceFolderPath(pathStr);
+		String baseBranch = configSettings.getBaseBranch(pathStr);
 		var reference = referenceFolder;
 		if (reference.isBlank()) {
 			reference = baseBranch;

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
@@ -26,7 +26,7 @@ public class SummaryBrowserHandler {
 					value = (Boolean) arguments[0];
 				}
 
-				Preferences.getInstance().store(Preferences.ENABLE_DELTA, Boolean.toString(value));
+				Preferences.getInstance().storeAndTrackChange(Preferences.ENABLE_DELTA, Boolean.toString(value));
 
 				CompletableFuture.runAsync(() -> SnykExtendedLanguageClient.getInstance().updateConfiguration());
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/BaseHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/handlers/BaseHandler.java
@@ -40,7 +40,7 @@ public class BaseHandler extends AbstractHandler implements IElementUpdater, IHa
 		String commandId = event.getCommand().getId();
 
 		// Update the application state for the preference.
-		Preferences.getInstance().store(preferenceKey,
+		Preferences.getInstance().storeAndTrackChange(preferenceKey,
 				Boolean.toString(!Preferences.getInstance().getBooleanPref(preferenceKey)));
 
 		updateUIForCommand(commandId);
@@ -102,7 +102,7 @@ public class BaseHandler extends AbstractHandler implements IElementUpdater, IHa
 		}
 	
 		for (String p : prefs) {			
-			preferences.store(p, Boolean.toString(!allEnabled));
+			preferences.storeAndTrackChange(p, Boolean.toString(!allEnabled));
 			updateUIForCommand(getCommandByPref(p));
 
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/wizards/SnykWizard.java
@@ -83,8 +83,8 @@ public class SnykWizard extends Wizard implements INewWizard {
 				monitor.subTask("saving preferences");
 				Preferences prefs = Preferences.getInstance();
 
-				prefs.store(Preferences.ENDPOINT_KEY, endpoint);
-				prefs.store(Preferences.INSECURE_KEY, unknownCerts);
+				prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, endpoint);
+				prefs.storeAndTrackChange(Preferences.INSECURE_KEY, unknownCerts);
 				monitor.subTask("updating language server configuration");
 				lc.updateConfiguration();
 				monitor.worked(20);

--- a/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConfigurationUpdater.java
@@ -1,20 +1,16 @@
 package io.snyk.languageserver;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 
 import io.snyk.eclipse.plugin.Activator;
-import io.snyk.eclipse.plugin.preferences.AuthConstants;
 import io.snyk.eclipse.plugin.preferences.Preferences;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
-import io.snyk.eclipse.plugin.properties.IssueViewOptions;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
-import io.snyk.languageserver.protocolextension.messageObjects.FilterSeverity;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfig;
-import io.snyk.languageserver.protocolextension.messageObjects.Settings;
+import io.snyk.languageserver.protocolextension.messageObjects.ConfigSetting;
+import io.snyk.languageserver.protocolextension.messageObjects.LspConfigurationParam;
 
 public class LsConfigurationUpdater {
 
@@ -24,74 +20,60 @@ public class LsConfigurationUpdater {
 			lc.ensureLanguageServerRunning();
 			var languageServer = lc.getConnectedLanguageServer();
 			var params = new DidChangeConfigurationParams();
-			params.setSettings(getCurrentSettings());
+			params.setSettings(buildConfigurationParam());
 			languageServer.getWorkspaceService().didChangeConfiguration(params);
 		}
 	}
 
-	Settings getCurrentSettings() {
+	LspConfigurationParam buildConfigurationParam() {
 		Preferences preferences = Preferences.getInstance();
-		String activateSnykOpenSource = preferences.getPref(Preferences.ACTIVATE_SNYK_OPEN_SOURCE,
-				Boolean.TRUE.toString());
-		String activateSnykCodeSecurity = preferences.getPref(Preferences.ACTIVATE_SNYK_CODE_SECURITY,
-				Boolean.FALSE.toString());
-		String activateSnykIac = preferences.getPref(Preferences.ACTIVATE_SNYK_IAC, Boolean.TRUE.toString());
-		String insecure = preferences.getPref(Preferences.INSECURE_KEY, Boolean.FALSE.toString());
-		String endpoint = preferences.getPref(Preferences.ENDPOINT_KEY, "");
-		String additionalParams = preferences.getPref(Preferences.ADDITIONAL_PARAMETERS, "");
-		String additionalEnv = preferences.getPref(Preferences.ADDITIONAL_ENVIRONMENT, "");
-		String path = preferences.getPref(Preferences.PATH_KEY, "");
-		IssueViewOptions issueViewOptions = new IssueViewOptions(
-				preferences.getBooleanPref(Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES, true),
-				preferences.getBooleanPref(Preferences.FILTER_IGNORES_SHOW_IGNORED_ISSUES, false));
-		String sendErrorReports = preferences.getPref(Preferences.SEND_ERROR_REPORTS, "");
-		String enableTelemetry = preferences.getPref(Preferences.ENABLE_TELEMETRY, Boolean.FALSE.toString());
-		String organization = preferences.getPref(Preferences.ORGANIZATION_KEY, "");
-		String manageBinariesAutomatically = preferences.getPref(Preferences.MANAGE_BINARIES_AUTOMATICALLY,
-				Boolean.TRUE.toString());
-		String cliPath = preferences.getCliPath();
-		String cliBaseDownloadURL = preferences.getPref(Preferences.CLI_BASE_URL, "https://downloads.snyk.io");
-		String token = preferences.getPref(Preferences.AUTH_TOKEN_KEY, "");
-		String integrationName = Activator.INTEGRATION_NAME;
-		String integrationVersion = Activator.PLUGIN_VERSION;
-		String automaticAuthentication = "false";
-		String trustedFoldersString = preferences.getPref(Preferences.TRUSTED_FOLDERS);
-		String[] trustedFolders = new String[0];
-		if (trustedFoldersString != null && !trustedFoldersString.isBlank()) {
-			trustedFolders = trustedFoldersString.split(File.pathSeparator);
-		}
-		String enableTrustedFolderFeature = Boolean.TRUE.toString();
-		String scanningMode = preferences.getBooleanPref(Preferences.SCANNING_MODE_AUTOMATIC) ? "automatic" : "manual";
-		String authenticationMethod = preferences.getPref(Preferences.AUTHENTICATION_METHOD, AuthConstants.AUTH_OAUTH2);
+		Map<String, ConfigSetting> settings = new LinkedHashMap<>();
 
-		String enableDeltaFindings = preferences.getPref(Preferences.ENABLE_DELTA, Boolean.FALSE.toString());
-
-		Integer riskScoreThreshold = null;
-		String riskScoreThresholdStr = preferences.getPref(Preferences.RISK_SCORE_THRESHOLD, "0");
-		try {
-			int value = Integer.parseInt(riskScoreThresholdStr);
-			if (value > 0) {
-				riskScoreThreshold = value;
+		for (LsSettingsRegistry.Entry entry : LsSettingsRegistry.ENTRIES.values()) {
+			if (entry.prefKey == null) {
+				settings.put(entry.lsKey.key, ConfigSetting.outbound(entry.outboundDefault, entry.isAlwaysChanged));
+				continue;
 			}
-		} catch (NumberFormatException e) { // NOPMD - invalid values default to null (no threshold)
+
+			String rawValue;
+			if (LsKey.CLI_PATH == entry.lsKey) {
+				rawValue = preferences.getCliPath();
+			} else {
+				rawValue = preferences.getPref(entry.prefKey, entry.outboundDefault);
+			}
+
+			Object lsValue = entry.outboundSerializer.apply(rawValue);
+
+			boolean changed = entry.isAlwaysChanged || preferences.isExplicitlyChanged(entry.prefKey);
+			for (String additionalKey : entry.additionalChangedPrefKeys) {
+				if (preferences.isExplicitlyChanged(additionalKey)) {
+					changed = true;
+					break;
+				}
+			}
+			settings.put(entry.lsKey.key, ConfigSetting.outbound(lsValue, changed));
 		}
 
-		// only add folder configs that are initialized
-		var folderConfigs = new ArrayList<FolderConfig>();
-		for (var p : Collections.unmodifiableSet(FolderConfigs.LanguageServerConfigReceived)) {
-			folderConfigs.add(FolderConfigs.getInstance().getFolderConfig(p));
-		}
+		String[] trustedFolders = (String[]) LsSettingsRegistry.ENTRIES.get(LsKey.TRUSTED_FOLDERS)
+				.outboundSerializer.apply(preferences.getPref(Preferences.TRUSTED_FOLDERS, ""));
 
-		FilterSeverity filterSeverity = new FilterSeverity(
-				preferences.getBooleanPref(Preferences.FILTER_SHOW_CRITICAL, true),
-				preferences.getBooleanPref(Preferences.FILTER_SHOW_HIGH, true),
-				preferences.getBooleanPref(Preferences.FILTER_SHOW_MEDIUM, true),
-				preferences.getBooleanPref(Preferences.FILTER_SHOW_LOW, true));
+		var folderConfigs = FolderConfigSettings.getInstance().getAll();
 
-		return new Settings(activateSnykOpenSource, activateSnykCodeSecurity, activateSnykIac,
-				insecure, endpoint, additionalParams, additionalEnv, path, issueViewOptions, sendErrorReports,
-				enableTelemetry, organization, manageBinariesAutomatically, cliPath, cliBaseDownloadURL, token,
-				integrationName, integrationVersion, automaticAuthentication, trustedFolders, enableTrustedFolderFeature,
-				scanningMode, enableDeltaFindings, riskScoreThreshold, authenticationMethod, folderConfigs, filterSeverity);
+		var param = new LspConfigurationParam(settings, folderConfigs);
+
+		param.setRequiredProtocolVersion(
+				io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
+		param.setIntegrationName(Activator.INTEGRATION_NAME);
+		param.setIntegrationVersion(Activator.PLUGIN_VERSION);
+		param.setRuntimeName(org.apache.commons.lang3.SystemUtils.JAVA_RUNTIME_NAME);
+		param.setRuntimeVersion(org.apache.commons.lang3.SystemUtils.JAVA_RUNTIME_VERSION);
+		param.setOsArch(org.apache.commons.lang3.SystemUtils.OS_ARCH);
+		param.setOsPlatform(org.apache.commons.lang3.SystemUtils.OS_NAME);
+		param.setPath(preferences.getPref(Preferences.PATH_KEY, ""));
+		param.setDeviceId(preferences.getPref(Preferences.DEVICE_ID, ""));
+		param.setTrustedFolders(trustedFolders);
+
+		return param;
 	}
+
 }

--- a/plugin/src/main/java/io/snyk/languageserver/LsConstants.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsConstants.java
@@ -27,7 +27,7 @@ public final class LsConstants {
 	public static final String SNYK_ADD_TRUSTED_FOLDERS = "$/snyk.addTrustedFolders";
 	public static final String SNYK_SCAN = "$/snyk.scan";
 	public static final String SNYK_PUBLISH_DIAGNOSTICS_316 = "$/snyk.publishDiagnostics316";
-	public static final String SNYK_FOLDER_CONFIG = "$/snyk.folderConfigs";
+	public static final String SNYK_CONFIGURATION = "$/snyk.configuration";
 	public static final String SNYK_SCAN_SUMMARY = "$/snyk.scanSummary";
 	public static final String SNYK_SHOW_DOCUMENT = "$/snyk.showDocument";
 }

--- a/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
@@ -29,6 +29,7 @@ public final class LsSettingsRegistry {
         public final Function<Object, String> inboundDeserializer;
         /** Always sent with changed=true — value treated as user-set regardless of tracking. */
         public final boolean isAlwaysChanged;
+        public final boolean encrypted;
         /** Included when the fallback HTML settings form is active. */
         public final boolean useInFallbackForm;
         /**
@@ -48,47 +49,53 @@ public final class LsSettingsRegistry {
                 Function<Object, String> inboundDeserializer,
                 boolean alwaysChanged, boolean useInFallbackForm,
                 String[] additionalChangedPrefKeys,
-                Function<com.fasterxml.jackson.databind.JsonNode, String> formDeserializer) {
+                Function<com.fasterxml.jackson.databind.JsonNode, String> formDeserializer,
+                boolean encrypted) {
             this.lsKey = lsKey;
             this.prefKey = prefKey;
             this.outboundDefault = outboundDefault;
             this.outboundSerializer = outboundSerializer;
             this.inboundDeserializer = inboundDeserializer;
             this.isAlwaysChanged = alwaysChanged;
+            this.encrypted = encrypted;
             this.useInFallbackForm = useInFallbackForm;
             this.additionalChangedPrefKeys = additionalChangedPrefKeys;
             this.formDeserializer = formDeserializer;
         }
 
         static Entry simple(LsKey lsKey, String prefKey, String outboundDefault) {
-            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, false, false, new String[0], null);
+            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, false, false, new String[0], null, false);
         }
 
         static Entry fallback(LsKey lsKey, String prefKey, String outboundDefault) {
-            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, false, true, new String[0], null);
+            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, false, true, new String[0], null, false);
         }
 
         /** Outbound sends Java Boolean (not string). LS GetBool handles both bool and "true"/"false". */
         static Entry bool(LsKey lsKey, String prefKey, boolean outboundDefault) {
             return new Entry(lsKey, prefKey, Boolean.toString(outboundDefault),
                     v -> Boolean.parseBoolean(v),
-                    LsSettingsRegistry::defaultToString, false, false, new String[0], null);
+                    LsSettingsRegistry::defaultToString, false, false, new String[0], null, false);
         }
 
         static Entry boolFallback(LsKey lsKey, String prefKey, boolean outboundDefault) {
             return new Entry(lsKey, prefKey, Boolean.toString(outboundDefault),
                     v -> Boolean.parseBoolean(v),
-                    LsSettingsRegistry::defaultToString, false, true, new String[0], null);
+                    LsSettingsRegistry::defaultToString, false, true, new String[0], null, false);
         }
 
         /** Value read from prefs normally, but always sent with changed=true. */
         static Entry alwaysChanged(LsKey lsKey, String prefKey, String outboundDefault) {
-            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, true, false, new String[0], null);
+            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, true, false, new String[0], null, false);
         }
 
         /** Hardcoded value (no pref), always sent with changed=true. Matches VSCode alwaysChanged+hardcoded resolve. */
         static Entry fixed(LsKey lsKey, String fixedValue) {
-            return new Entry(lsKey, null, fixedValue, v -> v, null, true, false, new String[0], null);
+            return new Entry(lsKey, null, fixedValue, v -> v, null, true, false, new String[0], null, false);
+        }
+
+        static Entry encryptedAlwaysChanged(LsKey lsKey, String prefKey, String outboundDefault) {
+            return new Entry(lsKey, prefKey, outboundDefault, v -> v, LsSettingsRegistry::defaultToString, true, false, new String[0], null, true);
         }
     }
 
@@ -111,7 +118,7 @@ public final class LsSettingsRegistry {
         Map<LsKey, Entry> entries = new EnumMap<>(LsKey.class);
 
         entries.put(LsKey.ENDPOINT,               Entry.simple(LsKey.ENDPOINT, Preferences.ENDPOINT_KEY, Preferences.DEFAULT_ENDPOINT));
-        entries.put(LsKey.TOKEN,                  Entry.alwaysChanged(LsKey.TOKEN, Preferences.AUTH_TOKEN_KEY, ""));
+        entries.put(LsKey.TOKEN,                  Entry.encryptedAlwaysChanged(LsKey.TOKEN, Preferences.AUTH_TOKEN_KEY, ""));
         entries.put(LsKey.ORGANIZATION,           Entry.simple(LsKey.ORGANIZATION, Preferences.ORGANIZATION_KEY, ""));
         entries.put(LsKey.AUTHENTICATION_METHOD,  Entry.simple(LsKey.AUTHENTICATION_METHOD, Preferences.AUTHENTICATION_METHOD, AuthConstants.AUTH_OAUTH2));
         entries.put(LsKey.AUTOMATIC_AUTHENTICATION, Entry.fixed(LsKey.AUTOMATIC_AUTHENTICATION, "false"));
@@ -123,7 +130,7 @@ public final class LsSettingsRegistry {
                 v -> Boolean.parseBoolean(v),
                 value -> String.valueOf(Boolean.TRUE.equals(value)),
                 false, false, new String[0],
-                node -> String.valueOf("auto".equals(node.asText()))));
+                node -> String.valueOf("auto".equals(node.asText())), false));
         entries.put(LsKey.ENABLE_DELTA_FINDINGS,  Entry.bool(LsKey.ENABLE_DELTA_FINDINGS, Preferences.ENABLE_DELTA, false));
         entries.put(LsKey.SEND_ERROR_REPORTS,     Entry.simple(LsKey.SEND_ERROR_REPORTS, Preferences.SEND_ERROR_REPORTS, ""));
         entries.put(LsKey.MANAGE_BINARIES_AUTOMATICALLY, Entry.boolFallback(LsKey.MANAGE_BINARIES_AUTOMATICALLY, Preferences.MANAGE_BINARIES_AUTOMATICALLY, true));
@@ -138,19 +145,19 @@ public final class LsSettingsRegistry {
         entries.put(LsKey.SEVERITY_FILTER_CRITICAL, new Entry(LsKey.SEVERITY_FILTER_CRITICAL, Preferences.FILTER_SHOW_CRITICAL, TRUE,
                 v -> Boolean.parseBoolean(v), LsSettingsRegistry::defaultToString, false, false,
                 new String[]{Preferences.FILTER_SHOW_HIGH, Preferences.FILTER_SHOW_MEDIUM, Preferences.FILTER_SHOW_LOW},
-                null));
+                null, false));
         entries.put(LsKey.SEVERITY_FILTER_HIGH, new Entry(LsKey.SEVERITY_FILTER_HIGH, Preferences.FILTER_SHOW_HIGH, TRUE,
                 v -> Boolean.parseBoolean(v), LsSettingsRegistry::defaultToString, false, false,
                 new String[]{Preferences.FILTER_SHOW_CRITICAL, Preferences.FILTER_SHOW_MEDIUM, Preferences.FILTER_SHOW_LOW},
-                null));
+                null, false));
         entries.put(LsKey.SEVERITY_FILTER_MEDIUM, new Entry(LsKey.SEVERITY_FILTER_MEDIUM, Preferences.FILTER_SHOW_MEDIUM, TRUE,
                 v -> Boolean.parseBoolean(v), LsSettingsRegistry::defaultToString, false, false,
                 new String[]{Preferences.FILTER_SHOW_CRITICAL, Preferences.FILTER_SHOW_HIGH, Preferences.FILTER_SHOW_LOW},
-                null));
+                null, false));
         entries.put(LsKey.SEVERITY_FILTER_LOW, new Entry(LsKey.SEVERITY_FILTER_LOW, Preferences.FILTER_SHOW_LOW, TRUE,
                 v -> Boolean.parseBoolean(v), LsSettingsRegistry::defaultToString, false, false,
                 new String[]{Preferences.FILTER_SHOW_CRITICAL, Preferences.FILTER_SHOW_HIGH, Preferences.FILTER_SHOW_MEDIUM},
-                null));
+                null, false));
         // risk_score_threshold: int or null (null = no threshold); "0" = no threshold in pref.
         entries.put(LsKey.RISK_SCORE_THRESHOLD, new Entry(LsKey.RISK_SCORE_THRESHOLD, Preferences.RISK_SCORE_THRESHOLD, "0",
                 v -> {
@@ -168,7 +175,7 @@ public final class LsSettingsRegistry {
                     return String.valueOf(value);
                 },
                 false, false, new String[0],
-                node -> node.isNull() ? "0" : String.valueOf(node.asInt())));
+                node -> node.isNull() ? "0" : String.valueOf(node.asInt()), false));
         // trusted_folders: always-changed array, also set top-level for InitializationOptions.
         entries.put(LsKey.TRUSTED_FOLDERS, new Entry(LsKey.TRUSTED_FOLDERS, Preferences.TRUSTED_FOLDERS, "",
                 v -> {
@@ -194,7 +201,7 @@ public final class LsSettingsRegistry {
                         sb.append(el.asText());
                     }
                     return sb.toString();
-                }));
+                }, false));
         entries.put(LsKey.CLI_RELEASE_CHANNEL,    Entry.fallback(LsKey.CLI_RELEASE_CHANNEL, Preferences.RELEASE_CHANNEL, "stable"));
 
         ENTRIES = Collections.unmodifiableMap(entries);

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -12,11 +12,13 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
 
+import com.google.gson.Gson;
+
 import io.snyk.eclipse.plugin.SnykStartup;
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.utils.Lists;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
-import io.snyk.languageserver.protocolextension.messageObjects.Settings;
+
 
 @SuppressWarnings("restriction")
 public class SnykLanguageServer extends ProcessStreamConnectionProvider implements StreamConnectionProvider {
@@ -112,13 +114,16 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 			waitForInit();
 		}
 
-		Settings currentSettings = null;
 		try {
-			currentSettings = new LsConfigurationUpdater().getCurrentSettings();
-		} catch (IllegalStateException | IllegalArgumentException e) {
+			var param = new LsConfigurationUpdater().buildConfigurationParam();
+			// Pre-serialize to JsonElement so LSP4J embeds the JSON directly
+			// instead of re-serializing through its own Gson instance, which
+			// can drop fields from custom POJOs like ConfigSetting.
+			return new Gson().toJsonTree(param);
+		} catch (Exception e) { // NOPMD - broad catch prevents LS handshake abort on unexpected errors
 			// Handle initialization errors gracefully - log and return null to allow LS to start
 			SnykLogger.logError(e);
 		}
-		return currentSettings;
+		return null;
 	}
 }

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -332,7 +333,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		var oldApi = prefs.getEndpoint();
 
 		String newToken = param.getToken();
-		boolean differentToken = !newToken.equals(oldToken);
+		boolean differentToken = !Objects.equals(newToken, oldToken);
 		boolean differentApi = param.getApiUrl() != null && !param.getApiUrl().isBlank() && !param.getApiUrl().equals(oldApi);
 
 		// Update UIs first, then persist to storage (avoids race conditions)

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -70,7 +70,7 @@ import io.snyk.eclipse.plugin.analytics.TaskProcessor;
 import io.snyk.eclipse.plugin.preferences.HTMLSettingsPreferencePage;
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.eclipse.plugin.preferences.PreferencesPage;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.eclipse.plugin.utils.ResourceUtils;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.eclipse.plugin.views.snyktoolview.FileTreeNode;
@@ -91,8 +91,8 @@ import io.snyk.languageserver.SnykIssueCache;
 import io.snyk.languageserver.SnykLanguageServer;
 import io.snyk.languageserver.protocolextension.messageObjects.Diagnostic316;
 import io.snyk.languageserver.protocolextension.messageObjects.FeatureFlagStatus;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfig;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfigsParam;
+import io.snyk.languageserver.protocolextension.messageObjects.ConfigSetting;
+import io.snyk.languageserver.protocolextension.messageObjects.LspConfigurationParam;
 import io.snyk.languageserver.protocolextension.messageObjects.HasAuthenticatedParam;
 import io.snyk.languageserver.protocolextension.messageObjects.LsSdk;
 import io.snyk.languageserver.protocolextension.messageObjects.PublishDiagnostics316Param;
@@ -200,17 +200,17 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			if (!Preferences.getInstance().isAuthenticated()) {
 				SnykWizard.createAndLaunch();
 			} else {
-				final var languageServerConfigReceived = FolderConfigs.LanguageServerConfigReceived;
+				var folderConfigSettings = FolderConfigSettings.getInstance();
 				updateConfiguration();
 				openToolView();
 				try {
 					if (projectPath != null) {
-						if (languageServerConfigReceived.contains(projectPath)) {
+						if (folderConfigSettings.isConfigured(projectPath.toString())) {
 							executeCommand(LsConstants.COMMAND_WORKSPACE_FOLDER_SCAN, List.of(projectPath.toString()));
 						}
 						return;
 					}
-					if (!languageServerConfigReceived.isEmpty()) {
+					if (!folderConfigSettings.getAll().isEmpty()) {
 						executeCommand(LsConstants.COMMAND_WORKSPACE_SCAN, new ArrayList<>());
 					}
 				} catch (Exception e) {
@@ -409,21 +409,47 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		this.toolView.refreshBrowser(param.getStatus());
 	}
 
-	@JsonNotification(value = LsConstants.SNYK_FOLDER_CONFIG)
-	public void folderConfig(FolderConfigsParam folderConfigParam) {
-		List<FolderConfig> folderConfigs = folderConfigParam != null ? folderConfigParam.getFolderConfigs() : List.of();
-		var fcs = FolderConfigs.getInstance();
-		for (FolderConfig folderConfig : folderConfigs) {
-			fcs.addFolderConfig(folderConfig);
-			final var folderPath = folderConfig.getFolderPath();
-			final var path = Paths.get(folderPath);
-			FolderConfigs.LanguageServerConfigReceived.add(path);
-			if (Preferences.getInstance().getBooleanPref(Preferences.SCANNING_MODE_AUTOMATIC)) {
-				this.triggerScan(path);
+	@JsonNotification(value = LsConstants.SNYK_CONFIGURATION)
+	public void snykConfiguration(LspConfigurationParam param) {
+		try {
+			if (param == null) {
+				return;
 			}
+
+			if (param.getSettings() != null) {
+				persistGlobalSettings(param.getSettings());
+			}
+
+			if (param.getFolderConfigs() != null) {
+				var folderConfigSettings = FolderConfigSettings.getInstance();
+				folderConfigSettings.addAll(param.getFolderConfigs());
+				if (Preferences.getInstance().getBooleanPref(Preferences.SCANNING_MODE_AUTOMATIC)) {
+					triggerScan(null);
+				}
+				if (this.toolView != null) {
+					this.toolView.refreshDeltaReference();
+				}
+			}
+		} catch (Exception e) {
+			SnykLogger.logError(e);
 		}
-		if (this.toolView != null) {
-			this.toolView.refreshDeltaReference();
+	}
+
+	private void persistGlobalSettings(java.util.Map<String, ConfigSetting> settings) {
+		var prefs = Preferences.getInstance();
+		for (var entry : settings.entrySet()) {
+			try {
+				var registryEntry = io.snyk.languageserver.LsSettingsRegistry.BY_LS_KEY.get(entry.getKey());
+				if (registryEntry == null || registryEntry.prefKey == null) {
+					continue;
+				}
+				var setting = entry.getValue();
+				if (setting.getValue() != null) {
+					prefs.store(registryEntry.prefKey, registryEntry.inboundDeserializer.apply(setting.getValue()));
+				}
+			} catch (Exception e) {
+				SnykLogger.logError(e);
+			}
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -30,7 +30,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -111,16 +110,6 @@ import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue
 public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	private static final String MARKER_TYPE = "io.snyk.languageserver.marker";
 
-	// Keys the LS is allowed to push back to the IDE. TOKEN is write-only (IDE → LS only).
-	private static final Set<LsKey> INBOUND_ALLOWED_GLOBAL_KEYS = EnumSet.of(
-			LsKey.ENDPOINT,
-			LsKey.ORGANIZATION,
-			LsKey.INSECURE,
-			LsKey.MANAGE_BINARIES_AUTOMATICALLY,
-			LsKey.CLI_PATH,
-			LsKey.CLI_BASE_DOWNLOAD_URL,
-			LsKey.CLI_RELEASE_CHANNEL
-	);
 	private ProgressManager progressManager = new ProgressManager(this);
 	private final ObjectMapper om = new ObjectMapper();
 	private TaskProcessor taskProcessor;
@@ -431,6 +420,9 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			if (param == null) {
 				return;
 			}
+			int settingsCount = param.getSettings() != null ? param.getSettings().size() : 0;
+			int folderCount = param.getFolderConfigs() != null ? param.getFolderConfigs().size() : 0;
+			SnykLogger.logInfo("$/snyk.configuration received: settings=" + settingsCount + ", folders=" + folderCount);
 
 			if (param.getSettings() != null) {
 				persistGlobalSettings(param.getSettings());
@@ -459,7 +451,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 				if (registryEntry == null || registryEntry.prefKey == null) {
 					continue;
 				}
-				if (!INBOUND_ALLOWED_GLOBAL_KEYS.contains(registryEntry.lsKey)) {
+				if (registryEntry.lsKey == LsKey.TOKEN) {
 					continue;
 				}
 				var setting = entry.getValue();

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -29,8 +29,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -100,11 +102,24 @@ import io.snyk.languageserver.protocolextension.messageObjects.SnykIsAvailableCl
 import io.snyk.languageserver.protocolextension.messageObjects.SnykScanParam;
 import io.snyk.languageserver.protocolextension.messageObjects.SnykTrustedFoldersParams;
 import io.snyk.languageserver.protocolextension.messageObjects.SummaryPanelParams;
+import io.snyk.languageserver.LsKey;
+import io.snyk.languageserver.LsSettingsRegistry;
 import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue;
 
 @SuppressWarnings({"restriction", "PMD.AvoidCatchingGenericException"})
 public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	private static final String MARKER_TYPE = "io.snyk.languageserver.marker";
+
+	// Keys the LS is allowed to push back to the IDE. TOKEN is write-only (IDE → LS only).
+	private static final Set<LsKey> INBOUND_ALLOWED_GLOBAL_KEYS = EnumSet.of(
+			LsKey.ENDPOINT,
+			LsKey.ORGANIZATION,
+			LsKey.INSECURE,
+			LsKey.MANAGE_BINARIES_AUTOMATICALLY,
+			LsKey.CLI_PATH,
+			LsKey.CLI_BASE_DOWNLOAD_URL,
+			LsKey.CLI_RELEASE_CHANNEL
+	);
 	private ProgressManager progressManager = new ProgressManager(this);
 	private final ObjectMapper om = new ObjectMapper();
 	private TaskProcessor taskProcessor;
@@ -439,8 +454,11 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		var prefs = Preferences.getInstance();
 		for (var entry : settings.entrySet()) {
 			try {
-				var registryEntry = io.snyk.languageserver.LsSettingsRegistry.BY_LS_KEY.get(entry.getKey());
+				var registryEntry = LsSettingsRegistry.BY_LS_KEY.get(entry.getKey());
 				if (registryEntry == null || registryEntry.prefKey == null) {
+					continue;
+				}
+				if (!INBOUND_ALLOWED_GLOBAL_KEYS.contains(registryEntry.lsKey)) {
 					continue;
 				}
 				var setting = entry.getValue();

--- a/plugin/src/main/resources/ui/html/settings-fallback.html
+++ b/plugin/src/main/resources/ui/html/settings-fallback.html
@@ -10,6 +10,9 @@
     {{CHANNEL_STABLE_SELECTED}} - "selected" or ""
     {{CHANNEL_RC_SELECTED}} - "selected" or ""
     {{CHANNEL_PREVIEW_SELECTED}} - "selected" or ""
+    {{CHANNEL_CUSTOM_SELECTED}} - "selected" or ""
+    {{CLI_RELEASE_CHANNEL_CUSTOM_VALUE}} - custom version string or ""
+    {{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}} - "hidden" or ""
     {{INSECURE_CHECKED}} - "checked" or ""
 -->
 <!DOCTYPE html>
@@ -185,6 +188,31 @@
       outline-offset: -1px;
     }
 
+    .cli-release-group {
+      display: flex;
+      align-items: center;
+    }
+
+    .cli-release-group select {
+      flex: 0 0 50%;
+    }
+
+    .cli-release-group input {
+      flex: 1 1 auto;
+      margin-left: 10px;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    .error-message {
+      color: var(--error-foreground);
+      font-size: 12px;
+      margin-top: 5px;
+      display: block;
+    }
+
     /* Info Message */
     .info-message {
       padding: var(--section-padding);
@@ -284,7 +312,7 @@
 
     <div class="form-group half-width">
       <label class="checkbox-label">
-        <input type="checkbox" name="insecure" id="insecure" {{INSECURE_CHECKED}}>
+        <input type="checkbox" name="proxy_insecure" id="proxy_insecure" {{INSECURE_CHECKED}}>
         <span data-toggle="tooltip">Insecure (Skip SSL Verification)<span class="tooltip-popup">If enabled, the plugin will ignore SSL certificate errors. Use this when connecting to self-signed or internal CA servers.</span></span>
       </label>
     </div>
@@ -294,29 +322,34 @@
     <h2>CLI Configuration</h2>
 
     <div class="form-group">
-      <label for="cliPath"><span data-toggle="tooltip">CLI Path<span class="tooltip-popup">Path to Snyk CLI executable</span></span></label>
-      <input type="text" id="cliPath" name="cliPath" value="{{CLI_PATH}}" placeholder="/path/to/snyk-cli">
+      <label for="cli_path"><span data-toggle="tooltip">CLI Path<span class="tooltip-popup">Path to Snyk CLI executable</span></span></label>
+      <input type="text" id="cli_path" name="cli_path" value="{{CLI_PATH}}" placeholder="/path/to/snyk-cli">
     </div>
 
     <div class="form-group half-width">
       <label class="checkbox-label">
-        <input type="checkbox" name="manageBinariesAutomatically" id="manageBinariesAutomatically" {{MANAGE_BINARIES_CHECKED}}>
+        <input type="checkbox" name="automatic_download" id="automatic_download" {{MANAGE_BINARIES_CHECKED}}>
         <span data-toggle="tooltip">Manage Binaries Automatically<span class="tooltip-popup">Automatically download and manage Snyk CLI binaries</span></span>
       </label>
     </div>
 
-    <div class="form-group half-width">
-      <label for="cliReleaseChannel"><span data-toggle="tooltip">CLI Release Channel<span class="tooltip-popup">Release channel for Snyk CLI downloads (Stable, Release Candidate or Preview)</span></span></label>
-      <select id="cliReleaseChannel" name="cliReleaseChannel">
-        <option value="stable" {{CHANNEL_STABLE_SELECTED}}>Stable</option>
-        <option value="rc" {{CHANNEL_RC_SELECTED}}>Release Candidate</option>
-        <option value="preview" {{CHANNEL_PREVIEW_SELECTED}}>Preview</option>
-      </select>
+    <div class="form-group">
+      <label for="cli_release_channel"><span data-toggle="tooltip">CLI Release<span class="tooltip-popup">Release channel or specific version for Snyk CLI downloads</span></span></label>
+      <div class="cli-release-group">
+        <select id="cli_release_channel" name="cli_release_channel">
+          <option value="stable" {{CHANNEL_STABLE_SELECTED}}>Stable</option>
+          <option value="rc" {{CHANNEL_RC_SELECTED}}>Release Candidate</option>
+          <option value="preview" {{CHANNEL_PREVIEW_SELECTED}}>Preview</option>
+          <option value="custom" {{CHANNEL_CUSTOM_SELECTED}}>Specify version…</option>
+        </select>
+        <input type="text" id="cli_release_channel_custom" name="cli_release_channel_custom" class="{{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}}" placeholder="e.g. v1.1292.0" value="{{CLI_RELEASE_CHANNEL_CUSTOM_VALUE}}" maxlength="20" pattern="^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$">
+      </div>
+      <span id="cli-version-error" class="error-message hidden">Invalid version format. Expected: v1.1234.0</span>
     </div>
 
     <div class="form-group">
-      <label for="cliBaseDownloadURL"><span data-toggle="tooltip">CLI Download Base URL<span class="tooltip-popup"><p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <strong>https://downloads.snyk.io/fips</strong></p></span></span></label>
-      <input type="text" id="cliBaseDownloadURL" name="cliBaseDownloadURL" value="{{CLI_BASE_DOWNLOAD_URL}}" placeholder="https://downloads.snyk.io">
+      <label for="binary_base_url"><span data-toggle="tooltip">CLI Download Base URL<span class="tooltip-popup"><p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <strong>https://downloads.snyk.io/fips</strong></p></span></span></label>
+      <input type="text" id="binary_base_url" name="binary_base_url" value="{{CLI_BASE_DOWNLOAD_URL}}" placeholder="https://downloads.snyk.io">
     </div>
   </div>
 </form>
@@ -337,11 +370,11 @@
     function collectData() {
       return {
         isFallbackForm: true,
-        cliPath: get('cliPath').value,
-        manageBinariesAutomatically: get('manageBinariesAutomatically').checked,
-        cliBaseDownloadURL: get('cliBaseDownloadURL').value || get('cliBaseDownloadURL').placeholder,
-        cliReleaseChannel: get('cliReleaseChannel').value,
-        insecure: get('insecure').checked
+        cli_path: get('cli_path').value,
+        automatic_download: get('automatic_download').checked,
+        binary_base_url: get('binary_base_url').value || get('binary_base_url').placeholder,
+        cli_release_channel: get('cli_release_channel').value === 'custom' ? (function() { var v = (get('cli_release_channel_custom').value || '').trim(); if (v && v.charAt(0) !== 'v') { v = 'v' + v; } return v || 'stable'; })() : get('cli_release_channel').value,
+        proxy_insecure: get('proxy_insecure').checked
       };
     }
 
@@ -413,6 +446,33 @@
       }
     }
 
+    function toggleCustomVersionInput() {
+      var sel = get('cli_release_channel');
+      var customInput = get('cli_release_channel_custom');
+      if (sel && customInput) {
+        if (sel.value === 'custom') {
+          customInput.className = customInput.className.replace(/\bhidden\b/, '').trim();
+        } else if (customInput.className.indexOf('hidden') === -1) {
+          customInput.className += ' hidden';
+        }
+      }
+    }
+
+    function validateCliVersion() {
+      var input = get('cli_release_channel_custom');
+      var error = get('cli-version-error');
+      if (!input || !error) return;
+      var value = input.value.trim();
+      var isValid = !value || /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(value);
+      if (isValid) {
+        if (error.className.indexOf('hidden') === -1) {
+          error.className += ' hidden';
+        }
+      } else {
+        error.className = error.className.replace(/\bhidden\b/, '').trim();
+      }
+    }
+
     window.addEventListener('load', function() {
       var form = get('configForm');
       if (!form) return;
@@ -435,6 +495,10 @@
         // Selects: use change event
         selects[j].addEventListener('change', markDirtyAndSave);
       }
+
+      get('cli_release_channel').addEventListener('change', toggleCustomVersionInput);
+
+      get('cli_release_channel_custom').addEventListener('input', validateCliVersion);
 
       // Attach tooltip repositioning on hover
       var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');

--- a/tests/src/test/java/io/snyk/eclipse/plugin/properties/FolderConfigSettingsTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/properties/FolderConfigSettingsTest.java
@@ -1,0 +1,475 @@
+package io.snyk.eclipse.plugin.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+
+import io.snyk.languageserver.LsFolderSettingsKeys;
+import io.snyk.languageserver.protocolextension.messageObjects.ConfigSetting;
+import io.snyk.languageserver.protocolextension.messageObjects.LspFolderConfig;
+
+class FolderConfigSettingsTest {
+
+	private final Gson gson = new Gson();
+	private FolderConfigSettings settings;
+
+	@BeforeEach
+	void setUp() {
+		settings = new FolderConfigSettings();
+		FolderConfigSettings.setInstance(settings);
+	}
+
+	@Test
+	void singletonReturnsInstance() {
+		FolderConfigSettings instance = FolderConfigSettings.getInstance();
+		assertNotNull(instance);
+		assertSame(instance, FolderConfigSettings.getInstance());
+	}
+
+	@Test
+	void addFolderConfigAndRetrieve() {
+		LspFolderConfig config = createFolderConfig("/home/user/project", "main");
+
+		settings.addFolderConfig(config);
+
+		LspFolderConfig result = settings.getFolderConfig("/home/user/project");
+		assertNotNull(result);
+		assertEquals("/home/user/project", result.getFolderPath());
+	}
+
+	@Test
+	void getFolderConfigReturnsEmptyForMissingPath() {
+		LspFolderConfig result = settings.getFolderConfig("/nonexistent");
+
+		assertNotNull(result);
+		assertNotNull(result.getSettings());
+		assertTrue(result.getSettings().isEmpty());
+	}
+
+	@Test
+	void addAllReplacesExisting() {
+		LspFolderConfig config1 = createFolderConfig("/project1", "main");
+		LspFolderConfig config2 = createFolderConfig("/project2", "develop");
+
+		settings.addFolderConfig(config1);
+		settings.addAll(List.of(config2));
+
+		// project1 should be gone (addAll clears and replaces)
+		assertFalse(settings.isConfigured("/project1"));
+
+		// project2 should be present
+		LspFolderConfig result2 = settings.getFolderConfig("/project2");
+		assertNotNull(result2.getSettings());
+	}
+
+	@Test
+	void getAllReturnsCopy() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		List<LspFolderConfig> all = settings.getAll();
+		assertEquals(1, all.size());
+
+		// Modifying returned list should not affect internal state
+		all.clear();
+		assertEquals(1, settings.getAll().size());
+	}
+
+	@Test
+	void pathNormalization() {
+		LspFolderConfig config = createFolderConfig("/home/user/./project/../project", "main");
+		settings.addFolderConfig(config);
+
+		LspFolderConfig result = settings.getFolderConfig("/home/user/project");
+		assertNotNull(result);
+		assertNotNull(result.getSettings());
+	}
+
+	@Test
+	void getBaseBranchReturnsValue() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		assertEquals("main", settings.getBaseBranch("/project"));
+	}
+
+	@Test
+	void getBaseBranchReturnsEmptyForMissingPath() {
+		assertEquals("", settings.getBaseBranch("/nonexistent"));
+	}
+
+	@Test
+	void getPreferredOrgReturnsValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"preferred_org": {
+							"value": "my-org"
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertEquals("my-org", settings.getPreferredOrg("/project"));
+	}
+
+	@Test
+	void getPreferredOrgReturnsEmptyForMissingPath() {
+		assertEquals("", settings.getPreferredOrg("/nonexistent"));
+	}
+
+	@Test
+	void getLocalBranchesReturnsValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"local_branches": {
+							"value": ["main", "develop", "feature/test"]
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		List<String> branches = settings.getLocalBranches("/project");
+		assertNotNull(branches);
+		assertEquals(3, branches.size());
+		assertTrue(branches.contains("main"));
+		assertTrue(branches.contains("develop"));
+		assertTrue(branches.contains("feature/test"));
+	}
+
+	@Test
+	void getLocalBranchesReturnsEmptyListForMissing() {
+		List<String> branches = settings.getLocalBranches("/nonexistent");
+		assertNotNull(branches);
+		assertTrue(branches.isEmpty());
+	}
+
+	@Test
+	void getAdditionalParametersReturnsListValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"additional_parameters": {
+							"value": ["--all-projects", "--debug"]
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		List<String> result = settings.getAdditionalParameters("/project");
+		assertEquals(2, result.size());
+		assertTrue(result.contains("--all-projects"));
+		assertTrue(result.contains("--debug"));
+	}
+
+	@Test
+	void getAdditionalParametersReturnsEmptyListForMissing() {
+		List<String> result = settings.getAdditionalParameters("/nonexistent");
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void getAdditionalParametersHandlesStringValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"additional_parameters": {
+							"value": "--all-projects"
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		List<String> result = settings.getAdditionalParameters("/project");
+		assertEquals(1, result.size());
+		assertEquals("--all-projects", result.get(0));
+	}
+
+	@Test
+	void getReferenceFolderPathReturnsValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"reference_folder_path": {
+							"value": "/ref/path"
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertEquals("/ref/path", settings.getReferenceFolderPath("/project"));
+	}
+
+	@Test
+	void getReferenceFolderPathReturnsEmptyForMissing() {
+		assertEquals("", settings.getReferenceFolderPath("/nonexistent"));
+	}
+
+	@Test
+	void isConfiguredReturnsFalseForMissingPath() {
+		assertFalse(settings.isConfigured("/nonexistent"));
+	}
+
+	@Test
+	void isConfiguredReturnsTrueWhenConfigExists() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		assertTrue(settings.isConfigured("/project"));
+	}
+
+	@Test
+	void isConfiguredReturnsTrueForEmptySettingsConfig() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertTrue(settings.isConfigured("/project"));
+	}
+
+	@Test
+	void isConfiguredReturnsFalseForNullPath() {
+		assertFalse(settings.isConfigured(null));
+	}
+
+	@Test
+	void isConfiguredUsesPathNormalization() {
+		LspFolderConfig config = createFolderConfig("/home/user/project", "main");
+		settings.addFolderConfig(config);
+
+		assertTrue(settings.isConfigured("/home/user/./project/../project"));
+	}
+
+	@Test
+	void updateFolderConfigStoresConfig() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		LspFolderConfig original = settings.getFolderConfig("/project");
+		LspFolderConfig updated = original.withSetting("base_branch", "develop", true);
+		settings.updateFolderConfig("/project", updated);
+
+		assertEquals("develop", settings.getBaseBranch("/project"));
+	}
+
+	@Test
+	void updateFolderConfigNormalizesPath() {
+		LspFolderConfig config = createFolderConfig("/home/user/project", "main");
+		settings.addFolderConfig(config);
+
+		LspFolderConfig updated = config.withSetting("base_branch", "develop", true);
+		settings.updateFolderConfig("/home/user/./project", updated);
+
+		assertEquals("develop", settings.getBaseBranch("/home/user/project"));
+	}
+
+	@Test
+	void updateFolderConfigCreatesNewEntryIfNotExist() {
+		LspFolderConfig config = createFolderConfig("/new-project", "feature");
+		settings.updateFolderConfig("/new-project", config);
+
+		assertTrue(settings.isConfigured("/new-project"));
+		assertEquals("feature", settings.getBaseBranch("/new-project"));
+	}
+
+	@Test
+	void isOrgSetByUserReturnsFalseForMissing() {
+		assertFalse(settings.isOrgSetByUser("/nonexistent"));
+	}
+
+	@Test
+	void isOrgSetByUserReturnsTrueWhenSet() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"org_set_by_user": {
+							"value": true
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertTrue(settings.isOrgSetByUser("/project"));
+	}
+
+	@Test
+	void isOrgSetByUserReturnsFalseWhenExplicitlyFalse() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"org_set_by_user": {
+							"value": false
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertFalse(settings.isOrgSetByUser("/project"));
+	}
+
+	@Test
+	void getAutoDeterminedOrgReturnsValue() {
+		String json = """
+				{
+					"folderPath": "/project",
+					"settings": {
+						"auto_determined_org": {
+							"value": "determined-org"
+						}
+					}
+				}
+				""";
+		LspFolderConfig config = gson.fromJson(json, LspFolderConfig.class);
+		settings.addFolderConfig(config);
+
+		assertEquals("determined-org", settings.getAutoDeterminedOrg("/project"));
+	}
+
+	@Test
+	void getAutoDeterminedOrgReturnsEmptyForMissing() {
+		assertEquals("", settings.getAutoDeterminedOrg("/nonexistent"));
+	}
+
+	@Test
+	void withSettingIntegration() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		LspFolderConfig original = settings.getFolderConfig("/project");
+		LspFolderConfig updated = original.withSetting("base_branch", "develop", true);
+		settings.addFolderConfig(updated);
+
+		assertEquals("develop", settings.getBaseBranch("/project"));
+	}
+
+	@Test
+	void computeFolderConfigAppliesUpdateAtomically() {
+		LspFolderConfig config = createFolderConfig("/project", "main");
+		settings.addFolderConfig(config);
+
+		settings.computeFolderConfig("/project",
+				c -> c.withSetting(LsFolderSettingsKeys.BASE_BRANCH, "develop", true));
+
+		assertEquals("develop", settings.getBaseBranch("/project"));
+	}
+
+	@Test
+	void computeFolderConfigCreatesNewConfigIfMissing() {
+		settings.computeFolderConfig("/new-project",
+				c -> c.withSetting(LsFolderSettingsKeys.BASE_BRANCH, "feature", true));
+
+		assertTrue(settings.isConfigured("/new-project"));
+		assertEquals("feature", settings.getBaseBranch("/new-project"));
+	}
+
+	@Test
+	void computeFolderConfigNormalizesPath() {
+		LspFolderConfig config = createFolderConfig("/home/user/project", "main");
+		settings.addFolderConfig(config);
+
+		settings.computeFolderConfig("/home/user/./project",
+				c -> c.withSetting(LsFolderSettingsKeys.BASE_BRANCH, "develop", true));
+
+		assertEquals("develop", settings.getBaseBranch("/home/user/project"));
+	}
+
+	@Test
+	void computeFolderConfigIgnoresNullPath() {
+		settings.computeFolderConfig(null,
+				c -> c.withSetting(LsFolderSettingsKeys.BASE_BRANCH, "develop", true));
+
+		assertTrue(settings.getAll().isEmpty());
+	}
+
+	@Test
+	void addAllDoesNotPreserveUnchangedKeys() {
+		// Existing key has changed=false (not a user override)
+		LspFolderConfig existing = createFolderConfig("/project", "old-branch");
+		settings.addFolderConfig(existing);
+
+		// LS sends new value
+		LspFolderConfig incoming = createFolderConfig("/project", "new-branch");
+		settings.addAll(List.of(incoming));
+
+		// Incoming wins because changed=false
+		assertEquals("new-branch", settings.getBaseBranch("/project"));
+	}
+
+	@Test
+	void addAllRemovesFoldersNoLongerReportedByLs() {
+		settings.addFolderConfig(createFolderConfig("/project1", "main"));
+		settings.addFolderConfig(createFolderConfig("/project2", "develop"));
+
+		// LS only reports project2 now
+		settings.addAll(List.of(createFolderConfig("/project2", "develop")));
+
+		assertEquals("", settings.getBaseBranch("/project1"));
+		assertEquals("develop", settings.getBaseBranch("/project2"));
+	}
+
+	@Test
+	void addAllAddsNewFolderNotPreviouslyKnown() {
+		LspFolderConfig newFolder = createFolderConfig("/new-project", "feature");
+		settings.addAll(List.of(newFolder));
+
+		assertEquals("feature", settings.getBaseBranch("/new-project"));
+	}
+
+	private LspFolderConfig createFolderConfig(String path, String baseBranch) {
+		String json = String.format("""
+				{
+					"folderPath": "%s",
+					"settings": {
+						"base_branch": {
+							"value": "%s",
+							"changed": false,
+							"source": "cli",
+							"originScope": "folder",
+							"isLocked": false
+						}
+					}
+				}
+				""", path, baseBranch);
+		return gson.fromJson(json, LspFolderConfig.class);
+	}
+}

--- a/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
@@ -209,4 +209,173 @@ class PreferencesTest {
 		assertFalse(Preferences.isNewConfigDialogEnabled());
 	}
 
+	@Test
+	public void testMarkExplicitlyChanged_addsKeyToSet() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		assertFalse(prefs.isExplicitlyChanged("endpoint"));
+		prefs.markExplicitlyChanged("endpoint");
+		assertTrue(prefs.isExplicitlyChanged("endpoint"));
+	}
+
+	@Test
+	public void testIsExplicitlyChanged_returnsFalseForUnchangedKey() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		assertFalse(prefs.isExplicitlyChanged("organization"));
+	}
+
+	@Test
+	public void testClearExplicitlyChanged_removesKeyFromSet() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.markExplicitlyChanged("endpoint");
+		assertTrue(prefs.isExplicitlyChanged("endpoint"));
+		prefs.clearExplicitlyChanged("endpoint");
+		assertFalse(prefs.isExplicitlyChanged("endpoint"));
+	}
+
+	@Test
+	public void testExplicitChanges_multipleKeys() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.markExplicitlyChanged("endpoint");
+		prefs.markExplicitlyChanged("organization");
+		assertTrue(prefs.isExplicitlyChanged("endpoint"));
+		assertTrue(prefs.isExplicitlyChanged("organization"));
+		assertFalse(prefs.isExplicitlyChanged("path"));
+	}
+
+	@Test
+	public void testExplicitChanges_persistedAsCommaSeparatedString() {
+		InMemoryPreferenceStore store = new InMemoryPreferenceStore();
+		Preferences prefs = Preferences.getTestInstance(store, new InMemorySecurePreferenceStore());
+		prefs.markExplicitlyChanged("endpoint");
+		prefs.markExplicitlyChanged("organization");
+
+		String persisted = store.get(Preferences.EXPLICIT_CHANGES_KEY, "");
+		assertTrue(persisted.contains("endpoint"));
+		assertTrue(persisted.contains("organization"));
+	}
+
+	@Test
+	public void testExplicitChanges_restoredFromPreferenceStoreOnConstruction() {
+		InMemoryPreferenceStore store = new InMemoryPreferenceStore();
+		store.put(Preferences.EXPLICIT_CHANGES_KEY, "endpoint,organization");
+
+		Preferences prefs = Preferences.getTestInstance(store, new InMemorySecurePreferenceStore());
+		assertTrue(prefs.isExplicitlyChanged("endpoint"));
+		assertTrue(prefs.isExplicitlyChanged("organization"));
+		assertFalse(prefs.isExplicitlyChanged("path"));
+	}
+
+	@Test
+	public void testStoreAndTrackChange_marksChangedWhenValueDiffers() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.store(Preferences.ENDPOINT_KEY, "https://old.endpoint.io");
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://new.endpoint.io");
+
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertEquals("https://new.endpoint.io", prefs.getPref(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	public void testStoreAndTrackChange_doesNotMarkChangedWhenValueSame() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.store(Preferences.ENDPOINT_KEY, "https://same.endpoint.io");
+
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://same.endpoint.io");
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	public void testStoreAndTrackChange_marksChangedOnFirstWrite() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+
+		prefs.storeAndTrackChange(Preferences.ORGANIZATION_KEY, "my-org");
+
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+		assertEquals("my-org", prefs.getPref(Preferences.ORGANIZATION_KEY));
+	}
+
+	@Test
+	public void testStoreAndTrackChange_doesNotFalsePositiveWhenValueMatchesRegisteredDefault() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		// ACTIVATE_SNYK_OPEN_SOURCE has a registered default of "true".
+		// storeAndTrackChange should compare against the registered default, not "".
+		prefs.storeAndTrackChange(Preferences.ACTIVATE_SNYK_OPEN_SOURCE, "true");
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ACTIVATE_SNYK_OPEN_SOURCE),
+				"Should not mark as changed when value matches registered default");
+	}
+
+	@Test
+	public void testStoreAndTrackChange_doesNotFalsePositiveForBooleanDefaults() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.storeAndTrackChange(Preferences.ACTIVATE_SNYK_IAC, "true");
+		prefs.storeAndTrackChange(Preferences.FILTER_SHOW_CRITICAL, "true");
+		prefs.storeAndTrackChange(Preferences.MANAGE_BINARIES_AUTOMATICALLY, "true");
+		prefs.storeAndTrackChange(Preferences.SCANNING_MODE_AUTOMATIC, "true");
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ACTIVATE_SNYK_IAC));
+		assertFalse(prefs.isExplicitlyChanged(Preferences.FILTER_SHOW_CRITICAL));
+		assertFalse(prefs.isExplicitlyChanged(Preferences.MANAGE_BINARIES_AUTOMATICALLY));
+		assertFalse(prefs.isExplicitlyChanged(Preferences.SCANNING_MODE_AUTOMATIC));
+	}
+
+	@Test
+	public void testStoreAndTrackChange_handlesNullKeyGracefully() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.storeAndTrackChange(null, "value");
+		// should not throw
+	}
+
+	@Test
+	public void testStoreAndTrackChange_handlesNullValueGracefully() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, null);
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	public void testClearExplicitlyChanged_resetFlowClearsOverride() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		// User sets a value
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://user-override.snyk.io");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+
+		// User resets the value (LS form sends null)
+		prefs.clearExplicitlyChanged(Preferences.ENDPOINT_KEY);
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+
+		// Value is still stored (clearing override doesn't erase the value)
+		assertEquals("https://user-override.snyk.io", prefs.getPref(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	public void testClearExplicitlyChanged_onlyAffectsSpecifiedKey() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(),
+				new InMemorySecurePreferenceStore());
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://custom.snyk.io");
+		prefs.storeAndTrackChange(Preferences.ORGANIZATION_KEY, "my-org");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+
+		prefs.clearExplicitlyChanged(Preferences.ENDPOINT_KEY);
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+	}
+
 }

--- a/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/properties/preferences/PreferencesTest.java
@@ -1,25 +1,13 @@
 package io.snyk.eclipse.plugin.properties.preferences;
 
 import static io.snyk.eclipse.plugin.preferences.Preferences.ACTIVATE_SNYK_CODE_SECURITY;
-import static io.snyk.eclipse.plugin.preferences.Preferences.ACTIVATE_SNYK_IAC;
 import static io.snyk.eclipse.plugin.preferences.Preferences.ACTIVATE_SNYK_OPEN_SOURCE;
 import static io.snyk.eclipse.plugin.preferences.Preferences.ANALYTICS_PLUGIN_INSTALLED_SENT;
-import static io.snyk.eclipse.plugin.preferences.Preferences.AUTHENTICATION_METHOD;
-import static io.snyk.eclipse.plugin.preferences.Preferences.CLI_BASE_URL;
-import static io.snyk.eclipse.plugin.preferences.Preferences.ENABLE_DELTA;
-import static io.snyk.eclipse.plugin.preferences.Preferences.ENDPOINT_KEY;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_IGNORES_SHOW_IGNORED_ISSUES;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_SHOW_CRITICAL;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_SHOW_HIGH;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_SHOW_LOW;
-import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_SHOW_MEDIUM;
 import static io.snyk.eclipse.plugin.preferences.Preferences.FILTER_SHOW_ONLY_FIXABLE;
 import static io.snyk.eclipse.plugin.preferences.Preferences.IS_GLOBAL_IGNORES_FEATURE_ENABLED;
 import static io.snyk.eclipse.plugin.preferences.Preferences.LSP_VERSION;
 import static io.snyk.eclipse.plugin.preferences.Preferences.MANAGE_BINARIES_AUTOMATICALLY;
 import static io.snyk.eclipse.plugin.preferences.Preferences.RELEASE_CHANNEL;
-import static io.snyk.eclipse.plugin.preferences.Preferences.SCANNING_MODE_AUTOMATIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,6 +26,7 @@ import io.snyk.eclipse.plugin.preferences.InMemoryPreferenceStore;
 import io.snyk.eclipse.plugin.preferences.InMemorySecurePreferenceStore;
 import io.snyk.eclipse.plugin.preferences.Preferences;
 import io.snyk.languageserver.LsRuntimeEnvironment;
+import io.snyk.languageserver.LsSettingsRegistry;
 
 class PreferencesTest {
 
@@ -53,26 +42,20 @@ class PreferencesTest {
 				new InMemorySecurePreferenceStore());
 		LsRuntimeEnvironment lsRuntimeEnv = new LsRuntimeEnvironment();
 
-		assertEquals("false", preferences.getPref(ACTIVATE_SNYK_CODE_SECURITY));
-		assertEquals("true", preferences.getPref(ACTIVATE_SNYK_OPEN_SOURCE));
-		assertEquals("true", preferences.getPref(ACTIVATE_SNYK_IAC));
-		assertEquals("true", preferences.getPref(FILTER_SHOW_CRITICAL));
-		assertEquals("true", preferences.getPref(FILTER_SHOW_HIGH));
-		assertEquals("true", preferences.getPref(FILTER_SHOW_MEDIUM));
-		assertEquals("true", preferences.getPref(FILTER_SHOW_LOW));
-		assertEquals("false", preferences.getPref(ENABLE_DELTA));
-		assertEquals("true", preferences.getPref(FILTER_IGNORES_SHOW_OPEN_ISSUES));
-		assertEquals("false", preferences.getPref(FILTER_IGNORES_SHOW_IGNORED_ISSUES));
+		// Registry-backed keys: assert stored default matches registry default to catch drift.
+		for (LsSettingsRegistry.Entry entry : LsSettingsRegistry.ENTRIES.values()) {
+			if (entry.prefKey == null || entry.encrypted || Preferences.CLI_PATH.equals(entry.prefKey)) {
+				continue;
+			}
+			assertEquals(entry.outboundDefault, preferences.getPref(entry.prefKey),
+					"Default mismatch for registry key: " + entry.lsKey);
+		}
+
+		// Non-registry keys with their own defaults.
 		assertEquals("false", preferences.getPref(FILTER_SHOW_ONLY_FIXABLE));
-		assertEquals("true", preferences.getPref(MANAGE_BINARIES_AUTOMATICALLY));
 		assertEquals("1", preferences.getPref(LSP_VERSION));
 		assertEquals("false", preferences.getPref(IS_GLOBAL_IGNORES_FEATURE_ENABLED));
-		assertEquals("https://api.snyk.io", preferences.getPref(ENDPOINT_KEY));
-		assertEquals("https://downloads.snyk.io", preferences.getPref(CLI_BASE_URL));
-		assertEquals("true", preferences.getPref(SCANNING_MODE_AUTOMATIC));
 		assertEquals("false", preferences.getPref(ANALYTICS_PLUGIN_INSTALLED_SENT));
-		assertEquals("stable", preferences.getPref(RELEASE_CHANNEL));
-		assertEquals(AuthConstants.AUTH_OAUTH2, preferences.getPref(AUTHENTICATION_METHOD));
 		assertTrue(preferences.getCliPath().endsWith(lsRuntimeEnv.getDownloadBinaryName()));
 	}
 

--- a/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
@@ -409,6 +409,33 @@ class LsConfigurationUpdaterTest {
 		assertTrue(settings.containsKey("issue_view_open_issues"));
 	}
 
+	@Test
+	void testBuildConfigurationParam_highRiskKeySerializedValues() {
+		setupPreferenceMock();
+
+		// risk_score_threshold: "200" pref → Integer(200), "0" → null
+		when(preferenceMock.getPref(Preferences.RISK_SCORE_THRESHOLD, "0")).thenReturn("200");
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertEquals(Integer.valueOf(200), param.getSettings().get(LsKey.RISK_SCORE_THRESHOLD.key).getValue(),
+				"risk_score_threshold must serialize as Integer, not String");
+
+		when(preferenceMock.getPref(Preferences.RISK_SCORE_THRESHOLD, "0")).thenReturn("0");
+		param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertNull(param.getSettings().get(LsKey.RISK_SCORE_THRESHOLD.key).getValue(),
+				"risk_score_threshold '0' must serialize as null (no threshold)");
+
+		// scan_automatic: pref "true" → Boolean.TRUE, "false" → Boolean.FALSE
+		when(preferenceMock.getPref(Preferences.SCANNING_MODE_AUTOMATIC, "true")).thenReturn("true");
+		param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertEquals(Boolean.TRUE, param.getSettings().get(LsKey.SCANNING_MODE.key).getValue(),
+				"scan_automatic must serialize as Boolean, not String");
+
+		when(preferenceMock.getPref(Preferences.SCANNING_MODE_AUTOMATIC, "true")).thenReturn("false");
+		param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertEquals(Boolean.FALSE, param.getSettings().get(LsKey.SCANNING_MODE.key).getValue(),
+				"scan_automatic false must serialize as Boolean.FALSE");
+	}
+
 	private void setupPreferenceMock() {
 		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_IAC, "true")).thenReturn("iac");
 		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_IAC, "false")).thenReturn("iac");

--- a/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
@@ -2,89 +2,411 @@ package io.snyk.languageserver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.core.runtime.Platform;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.Version;
 
-import io.snyk.eclipse.plugin.Activator;
+import com.google.gson.Gson;
+
 import io.snyk.eclipse.plugin.preferences.AuthConstants;
 import io.snyk.eclipse.plugin.preferences.Preferences;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.eclipse.plugin.properties.preferences.PreferencesUtils;
-import io.snyk.languageserver.download.LsBinaries;
+import io.snyk.languageserver.protocolextension.messageObjects.ConfigSetting;
+import io.snyk.languageserver.protocolextension.messageObjects.LspConfigurationParam;
+import io.snyk.languageserver.protocolextension.messageObjects.LspFolderConfig;
 
 class LsConfigurationUpdaterTest {
 	private Preferences preferenceMock;
-	FolderConfigs mockFolderConfigs;
+	private final Gson gson = new Gson();
 
 	@BeforeEach
 	protected void setUp() {
 		preferenceMock = mock(Preferences.class);
 		PreferencesUtils.setPreferences(preferenceMock);
 
-		mockFolderConfigs = mock(FolderConfigs.class);
-		FolderConfigs.setInstance(mockFolderConfigs);
+		FolderConfigSettings.setInstance(new FolderConfigSettings());
 	}
 
 	@Test
-	void testGetSettings() {
+	void testBuildConfigurationParam_returnsLspConfigurationParam() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertNotNull(param);
+		assertNotNull(param.getSettings());
+		assertNotNull(param.getFolderConfigs());
+	}
+
+	@Test
+	void testBuildConfigurationParam_containsMachineSettings() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		assertNotNull(settings.get(LsKey.ENDPOINT.key));
+		assertEquals("endpoint", settings.get(LsKey.ENDPOINT.key).getValue());
+
+		assertNotNull(settings.get(LsKey.ORGANIZATION.key));
+		assertEquals("organization", settings.get(LsKey.ORGANIZATION.key).getValue());
+	}
+
+	@Test
+	void testBuildConfigurationParam_changedFlagFromExplicitChanges() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.ENDPOINT_KEY)).thenReturn(true);
+		when(preferenceMock.isExplicitlyChanged(Preferences.ORGANIZATION_KEY)).thenReturn(false);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		assertTrue(settings.get(LsKey.ENDPOINT.key).getChanged());
+		assertFalse(settings.get(LsKey.ORGANIZATION.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_tokenChangedFlagFromExplicitChanges() {
 		setupPreferenceMock();
 
-		try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {
-			var bundleMock = mock(Bundle.class);
-			when(bundleMock.getVersion()).thenReturn(new Version("1.2.3"));
-			platformMockedStatic.when(() -> Platform.getBundle(Activator.PLUGIN_ID)).thenReturn(bundleMock);
-			var settings = new LsConfigurationUpdater().getCurrentSettings();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		ConfigSetting tokenSetting = param.getSettings().get(LsKey.TOKEN.key);
 
-			assertEquals("iac", settings.getActivateSnykIac());
-			assertEquals("code", settings.getActivateSnykCodeSecurity());
-			assertEquals("oss", settings.getActivateSnykOpenSource());
-			assertEquals("true", settings.getInsecure());
-			assertEquals("endpoint", settings.getEndpoint());
-			assertEquals("addParams", settings.getAdditionalParams());
-			assertEquals("a=b;c=d", settings.getAdditionalEnv());
-			assertEquals("path", settings.getPath());
-			assertEquals("true", settings.getSendErrorReports());
-			assertEquals("organization", settings.getOrganization());
-			assertEquals("true", settings.getEnableTelemetry());
-			assertEquals("true", settings.getManageBinariesAutomatically());
-			assertEquals("/usr/local/bin/snyk", settings.getCliPath());
-			assertEquals("ECLIPSE", settings.getIntegrationName());
-			assertEquals(Activator.PLUGIN_VERSION, settings.getIntegrationVersion());
-			assertEquals("false", settings.getAutomaticAuthentication());
-			assertEquals(SystemUtils.JAVA_RUNTIME_NAME, settings.getRuntimeName());
-			assertEquals(SystemUtils.JAVA_RUNTIME_VERSION, settings.getRuntimeVersion());
-			assertEquals(SystemUtils.OS_ARCH, settings.getOsArch());
-			assertEquals(SystemUtils.OS_NAME, settings.getOsPlatform());
+		assertTrue(tokenSetting.getChanged());
+	}
 
-			// Additional assertions based on setupPreferenceMock
-			assertEquals("/usr/local/bin/snyk", settings.getCliPath());
-			assertEquals("my-token", settings.getToken());
-			assertEquals("automatic", settings.getScanningMode());
-			assertEquals(AuthConstants.AUTH_OAUTH2, settings.getAuthenticationMethod());
-			assertEquals(LsBinaries.REQUIRED_LS_PROTOCOL_VERSION, settings.getRequiredProtocolVersion());
+	@Test
+	void testBuildConfigurationParam_tokenAlwaysChanged() {
+		setupPreferenceMock();
 
-			// Verify risk score threshold is included
-			assertEquals(Integer.valueOf(200), settings.getRiskScoreThreshold());
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		ConfigSetting tokenSetting = param.getSettings().get(LsKey.TOKEN.key);
 
-			// Verify filter severity is included
-			assertNotNull(settings.getFilterSeverity());
-			assertTrue(settings.getFilterSeverity().isCritical());
-			assertFalse(settings.getFilterSeverity().isHigh());
-			assertTrue(settings.getFilterSeverity().isMedium());
-			assertFalse(settings.getFilterSeverity().isLow());
+		assertTrue(tokenSetting.getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_outboundHasNoLockMetadata() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		for (ConfigSetting setting : settings.values()) {
+			assertNull(setting.getSource());
+			assertNull(setting.getOriginScope());
+			assertNull(setting.getIsLocked());
 		}
+	}
+
+	@Test
+	void testBuildConfigurationParam_fullStateSemanticsAllSettingsIncluded() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		assertTrue(settings.containsKey(LsKey.ENDPOINT.key));
+		assertTrue(settings.containsKey(LsKey.ORGANIZATION.key));
+		assertTrue(settings.containsKey(LsKey.ACTIVATE_SNYK_CODE.key));
+		assertTrue(settings.containsKey(LsKey.ACTIVATE_SNYK_OPEN_SOURCE.key));
+		assertTrue(settings.containsKey(LsKey.ACTIVATE_SNYK_IAC.key));
+		assertTrue(settings.containsKey(LsKey.ACTIVATE_SNYK_SECRETS.key));
+		assertTrue(settings.containsKey(LsKey.INSECURE.key));
+		assertTrue(settings.containsKey(LsKey.ADDITIONAL_PARAMS.key));
+		assertTrue(settings.containsKey(LsKey.SCANNING_MODE.key));
+	}
+
+	@Test
+	void testBuildConfigurationParam_resetToDefault_sendsNullValueWithChangedTrue() {
+		setupPreferenceMock();
+		when(preferenceMock.getPref(Preferences.ENDPOINT_KEY, Preferences.DEFAULT_ENDPOINT)).thenReturn(null);
+		when(preferenceMock.isExplicitlyChanged(Preferences.ENDPOINT_KEY)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		ConfigSetting endpointSetting = param.getSettings().get(LsKey.ENDPOINT.key);
+
+		assertNull(endpointSetting.getValue());
+		assertTrue(endpointSetting.getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_unchangedSettingHasChangedFalse() {
+		setupPreferenceMock();
+		when(preferenceMock.getPref(Preferences.ENDPOINT_KEY, Preferences.DEFAULT_ENDPOINT)).thenReturn(Preferences.DEFAULT_ENDPOINT);
+		when(preferenceMock.isExplicitlyChanged(Preferences.ENDPOINT_KEY)).thenReturn(false);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		ConfigSetting endpointSetting = param.getSettings().get(LsKey.ENDPOINT.key);
+
+		assertFalse(endpointSetting.getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_folderConfigsFromFolderConfigSettings() {
+		setupPreferenceMock();
+
+		String folderJson = """
+				{
+					"folderPath": "/test/project",
+					"settings": {
+						"base_branch": {"value": "main", "changed": false}
+					}
+				}
+				""";
+		LspFolderConfig folderConfig = gson.fromJson(folderJson, LspFolderConfig.class);
+		FolderConfigSettings folderConfigSettings = new FolderConfigSettings();
+		folderConfigSettings.addFolderConfig(folderConfig);
+		FolderConfigSettings.setInstance(folderConfigSettings);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		List<LspFolderConfig> folderConfigs = param.getFolderConfigs();
+
+		assertEquals(1, folderConfigs.size());
+	}
+
+	@Test
+	void testRoundTrip_userChangeProducesCorrectPayload() {
+		setupPreferenceMock();
+		when(preferenceMock.getPref(Preferences.ENDPOINT_KEY, Preferences.DEFAULT_ENDPOINT)).thenReturn("https://custom.api.snyk.io");
+		when(preferenceMock.isExplicitlyChanged(Preferences.ENDPOINT_KEY)).thenReturn(true);
+		when(preferenceMock.getPref(Preferences.ORGANIZATION_KEY, "")).thenReturn("my-org");
+		when(preferenceMock.isExplicitlyChanged(Preferences.ORGANIZATION_KEY)).thenReturn(true);
+		when(preferenceMock.isExplicitlyChanged(Preferences.INSECURE_KEY)).thenReturn(true);
+
+		String folderJson = """
+				{
+					"folderPath": "/workspace/project-a",
+					"settings": {
+						"base_branch": {"value": "develop", "changed": false, "source": "cli", "originScope": "folder"}
+					}
+				}
+				""";
+		LspFolderConfig folderConfig = gson.fromJson(folderJson, LspFolderConfig.class);
+		LspFolderConfig updatedFolder = folderConfig.withSetting("base_branch", "main", true);
+		FolderConfigSettings folderConfigSettings = new FolderConfigSettings();
+		folderConfigSettings.addFolderConfig(updatedFolder);
+		FolderConfigSettings.setInstance(folderConfigSettings);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+
+		// Machine-scope settings with changed=true
+		assertTrue(param.getSettings().get(LsKey.ENDPOINT.key).getChanged());
+		assertEquals("https://custom.api.snyk.io", param.getSettings().get(LsKey.ENDPOINT.key).getValue());
+		assertTrue(param.getSettings().get(LsKey.ORGANIZATION.key).getChanged());
+		assertEquals("my-org", param.getSettings().get(LsKey.ORGANIZATION.key).getValue());
+
+		// Folder config with user override
+		assertEquals(1, param.getFolderConfigs().size());
+		LspFolderConfig fc = param.getFolderConfigs().get(0);
+		ConfigSetting baseBranch = fc.getSettings().get("base_branch");
+		assertEquals("main", baseBranch.getValue());
+		assertTrue(baseBranch.getChanged());
+		assertEquals("cli", baseBranch.getSource());
+		assertEquals("folder", baseBranch.getOriginScope());
+
+		assertTrue(param.getSettings().get(LsKey.INSECURE.key).getChanged());
+
+		// No lock metadata on machine-scope settings
+		assertNull(param.getSettings().get(LsKey.ENDPOINT.key).getSource());
+		assertNull(param.getSettings().get(LsKey.ENDPOINT.key).getIsLocked());
+
+		// Metadata fields are at the top level, not in settings map
+		assertNotNull(param.getIntegrationName());
+		assertNotNull(param.getRequiredProtocolVersion());
+		assertNotNull(param.getTrustedFolders());
+
+		// Serialize to verify it's valid JSON structure
+		String json = gson.toJson(param);
+		LspConfigurationParam deserialized = gson.fromJson(json, LspConfigurationParam.class);
+		assertNotNull(deserialized.getSettings());
+		assertNotNull(deserialized.getFolderConfigs());
+	}
+
+	@Test
+	void testBuildConfigurationParam_snykSecretsEnabledPresentAndChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.ACTIVATE_SNYK_SECRETS)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		ConfigSetting setting = param.getSettings().get(LsKey.ACTIVATE_SNYK_SECRETS.key);
+
+		assertNotNull(setting);
+		assertTrue(setting.getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_sendErrorReportsChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.SEND_ERROR_REPORTS)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.SEND_ERROR_REPORTS.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_manageBinariesChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.MANAGE_BINARIES_AUTOMATICALLY)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.MANAGE_BINARIES_AUTOMATICALLY.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_cliPathChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.CLI_PATH)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.CLI_PATH.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_cliBaseDownloadUrlChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.CLI_BASE_URL)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.CLI_BASE_DOWNLOAD_URL.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_authenticationMethodChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.AUTHENTICATION_METHOD)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.AUTHENTICATION_METHOD.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_enableDeltaChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.ENABLE_DELTA)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.ENABLE_DELTA_FINDINGS.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_riskScoreThresholdChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.RISK_SCORE_THRESHOLD)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.RISK_SCORE_THRESHOLD.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_issueViewOpenIssuesChangedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.ISSUE_VIEW_OPEN_ISSUES.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_issueViewIgnoredIssuesUnchangedWhenNotExplicitlyChanged() {
+		setupPreferenceMock();
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertFalse(param.getSettings().get(LsKey.ISSUE_VIEW_IGNORED_ISSUES.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_severityFilterSentAsIndividualKeys() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.FILTER_SHOW_CRITICAL)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		// LS expects individual boolean keys, not a composite "enabled_severities" object
+		assertNotNull(settings.get(LsKey.SEVERITY_FILTER_CRITICAL.key));
+		assertNotNull(settings.get(LsKey.SEVERITY_FILTER_HIGH.key));
+		assertNotNull(settings.get(LsKey.SEVERITY_FILTER_MEDIUM.key));
+		assertNotNull(settings.get(LsKey.SEVERITY_FILTER_LOW.key));
+
+		assertEquals(Boolean.TRUE, settings.get(LsKey.SEVERITY_FILTER_CRITICAL.key).getValue());
+		assertEquals(Boolean.FALSE, settings.get(LsKey.SEVERITY_FILTER_HIGH.key).getValue());
+		assertEquals(Boolean.TRUE, settings.get(LsKey.SEVERITY_FILTER_MEDIUM.key).getValue());
+		assertEquals(Boolean.FALSE, settings.get(LsKey.SEVERITY_FILTER_LOW.key).getValue());
+	}
+
+	@Test
+	void testBuildConfigurationParam_severityFilterChangedWhenAnySeverityChanged() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.FILTER_SHOW_LOW)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		// All 4 severity keys share the anySeverityChanged flag
+		assertTrue(param.getSettings().get(LsKey.SEVERITY_FILTER_LOW.key).getChanged());
+		assertTrue(param.getSettings().get(LsKey.SEVERITY_FILTER_CRITICAL.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_severityFilterUnchangedWhenNoSeverityChanged() {
+		setupPreferenceMock();
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertFalse(param.getSettings().get(LsKey.SEVERITY_FILTER_CRITICAL.key).getChanged());
+		assertFalse(param.getSettings().get(LsKey.SEVERITY_FILTER_HIGH.key).getChanged());
+	}
+
+	@Test
+	void testBuildConfigurationParam_noCompositeEnabledSeveritiesKey() {
+		setupPreferenceMock();
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+		assertFalse(settings.containsKey("enabled_severities"),
+				"LS has no 'enabled_severities' key; individual severity_filter_* keys required");
+	}
+
+	@Test
+	void testBuildConfigurationParam_metadataFieldsAreTopLevel() {
+		setupPreferenceMock();
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+
+		assertNotNull(param.getIntegrationName());
+		assertNotNull(param.getIntegrationVersion());
+		assertNotNull(param.getRequiredProtocolVersion());
+		assertNotNull(param.getRuntimeName());
+		assertNotNull(param.getRuntimeVersion());
+		assertNotNull(param.getOsArch());
+		assertNotNull(param.getOsPlatform());
+		assertNotNull(param.getTrustedFolders());
+	}
+
+	@Test
+	void testBuildConfigurationParam_settingsUseSnakeCaseKeys() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		Map<String, ConfigSetting> settings = param.getSettings();
+
+		// Verify settings keys are snake_case
+		assertTrue(settings.containsKey("api_endpoint"));
+		assertTrue(settings.containsKey("cli_path"));
+		assertTrue(settings.containsKey("proxy_insecure"));
+		assertTrue(settings.containsKey("snyk_code_enabled"));
+		assertTrue(settings.containsKey("snyk_oss_enabled"));
+		assertTrue(settings.containsKey("snyk_iac_enabled"));
+		assertTrue(settings.containsKey("scan_automatic"));
+		assertTrue(settings.containsKey("automatic_download"));
+		assertTrue(settings.containsKey("binary_base_url"));
+		assertTrue(settings.containsKey("scan_net_new"));
+		assertTrue(settings.containsKey("severity_filter_critical"));
+		assertTrue(settings.containsKey("severity_filter_high"));
+		assertTrue(settings.containsKey("severity_filter_medium"));
+		assertTrue(settings.containsKey("severity_filter_low"));
+		assertTrue(settings.containsKey("issue_view_open_issues"));
 	}
 
 	private void setupPreferenceMock() {
@@ -97,10 +419,13 @@ class LsConfigurationUpdaterTest {
 		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_OPEN_SOURCE, "true")).thenReturn("oss");
 		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_OPEN_SOURCE, "false")).thenReturn("oss");
 		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_OPEN_SOURCE, "")).thenReturn("oss");
+		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_SECRETS, "true")).thenReturn("false");
+		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_SECRETS, "false")).thenReturn("false");
+		when(preferenceMock.getPref(Preferences.ACTIVATE_SNYK_SECRETS, "")).thenReturn("false");
 		when(preferenceMock.getPref(Preferences.INSECURE_KEY, "")).thenReturn("true");
 		when(preferenceMock.getPref(Preferences.INSECURE_KEY, "true")).thenReturn("true");
 		when(preferenceMock.getPref(Preferences.INSECURE_KEY, "false")).thenReturn("true");
-		when(preferenceMock.getPref(Preferences.ENDPOINT_KEY, "")).thenReturn("endpoint");
+		when(preferenceMock.getPref(Preferences.ENDPOINT_KEY, Preferences.DEFAULT_ENDPOINT)).thenReturn("endpoint");
 		when(preferenceMock.getPref(Preferences.ADDITIONAL_PARAMETERS, "")).thenReturn("addParams");
 		when(preferenceMock.getPref(Preferences.ADDITIONAL_ENVIRONMENT, "")).thenReturn("a=b;c=d");
 		when(preferenceMock.getPref(Preferences.PATH_KEY, "")).thenReturn("path");
@@ -119,11 +444,24 @@ class LsConfigurationUpdaterTest {
 		when(preferenceMock.getBooleanPref(Preferences.SCANNING_MODE_AUTOMATIC)).thenReturn(true);
 		when(preferenceMock.getPref(Preferences.ENABLE_DELTA, Boolean.FALSE.toString())).thenReturn("true");
 		when(preferenceMock.getPref(Preferences.RISK_SCORE_THRESHOLD, "0")).thenReturn("200");
+		when(preferenceMock.getReleaseChannel()).thenReturn("stable");
+		when(preferenceMock.getPref(Preferences.DEVICE_ID, "")).thenReturn("test-device-id");
+		when(preferenceMock.getPref(Preferences.TRUSTED_FOLDERS)).thenReturn("");
+		when(preferenceMock.getPref(Preferences.CLI_BASE_URL, "https://downloads.snyk.io")).thenReturn("https://downloads.snyk.io");
 
 		// Severity filter mocks
 		when(preferenceMock.getBooleanPref(Preferences.FILTER_SHOW_CRITICAL, true)).thenReturn(true);
 		when(preferenceMock.getBooleanPref(Preferences.FILTER_SHOW_HIGH, true)).thenReturn(false);
 		when(preferenceMock.getBooleanPref(Preferences.FILTER_SHOW_MEDIUM, true)).thenReturn(true);
 		when(preferenceMock.getBooleanPref(Preferences.FILTER_SHOW_LOW, true)).thenReturn(false);
+		when(preferenceMock.getPref(Preferences.FILTER_SHOW_CRITICAL, "true")).thenReturn("true");
+		when(preferenceMock.getPref(Preferences.FILTER_SHOW_HIGH, "true")).thenReturn("false");
+		when(preferenceMock.getPref(Preferences.FILTER_SHOW_MEDIUM, "true")).thenReturn("true");
+		when(preferenceMock.getPref(Preferences.FILTER_SHOW_LOW, "true")).thenReturn("false");
+
+		// Issue view options mocks
+		when(preferenceMock.getBooleanPref(Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES, true)).thenReturn(true);
+		when(preferenceMock.getBooleanPref(Preferences.FILTER_IGNORES_SHOW_IGNORED_ISSUES, false)).thenReturn(false);
+		when(preferenceMock.getPref(Preferences.SCANNING_MODE_AUTOMATIC, "true")).thenReturn("true");
 	}
 }

--- a/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
@@ -11,8 +11,11 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import io.snyk.eclipse.plugin.preferences.Preferences;
-import io.snyk.languageserver.protocolextension.messageObjects.Settings;
+import io.snyk.languageserver.LsKey;
 
 class SnykLanguageServerTest extends LsBaseTest {
 
@@ -24,7 +27,34 @@ class SnykLanguageServerTest extends LsBaseTest {
 
     Object output = snykStreamConnectionProvider.getInitializationOptions(null);
 
-    assertInstanceOf(Settings.class, output);
+    assertInstanceOf(JsonElement.class, output);
+    JsonObject root = ((JsonElement) output).getAsJsonObject();
+    assertTrue(root.has("settings"), "root should have 'settings' key");
+    assertTrue(root.has("folderConfigs"), "root should have 'folderConfigs' key");
+
+    // Metadata fields should be at the top level
+    assertTrue(root.has("integrationName"), "root should have 'integrationName'");
+    assertTrue(root.has("requiredProtocolVersion"), "root should have 'requiredProtocolVersion'");
+
+    JsonObject settings = root.getAsJsonObject("settings");
+    for (var field : new String[] {
+        LsKey.ENDPOINT.key, LsKey.ORGANIZATION.key, LsKey.TOKEN.key,
+        LsKey.ACTIVATE_SNYK_CODE.key, LsKey.ACTIVATE_SNYK_OPEN_SOURCE.key,
+        LsKey.ACTIVATE_SNYK_IAC.key, LsKey.INSECURE.key,
+        LsKey.ADDITIONAL_PARAMS.key, LsKey.SCANNING_MODE.key,
+        LsKey.CLI_PATH.key, LsKey.CLI_BASE_DOWNLOAD_URL.key,
+        LsKey.AUTHENTICATION_METHOD.key,
+        LsKey.MANAGE_BINARIES_AUTOMATICALLY.key,
+        LsKey.SEVERITY_FILTER_CRITICAL.key,
+        LsKey.SEVERITY_FILTER_HIGH.key,
+        LsKey.SEVERITY_FILTER_MEDIUM.key,
+        LsKey.SEVERITY_FILTER_LOW.key,
+        LsKey.ISSUE_VIEW_OPEN_ISSUES.key, LsKey.ISSUE_VIEW_IGNORED_ISSUES.key
+    }) {
+      assertTrue(settings.has(field), "settings should contain '" + field + "'");
+      assertTrue(settings.getAsJsonObject(field).has("value"),
+          "'" + field + "' should have a 'value' property");
+    }
   }
 
   @Test
@@ -35,10 +65,13 @@ class SnykLanguageServerTest extends LsBaseTest {
 
     Object output = snykStreamConnectionProvider.getInitializationOptions(null);
 
-    assertInstanceOf(Settings.class, output);
-    Settings settings = (Settings) output;
-    assertEquals("a", settings.getTrustedFolders()[0]);
-    assertEquals("b/c", settings.getTrustedFolders()[1]);
+    assertInstanceOf(JsonElement.class, output);
+    JsonObject root = ((JsonElement) output).getAsJsonObject();
+    var foldersArray = root.getAsJsonArray("trustedFolders");
+    assertNotNull(foldersArray);
+    assertEquals(2, foldersArray.size());
+    assertEquals("a", foldersArray.get(0).getAsString());
+    assertEquals("b/c", foldersArray.get(1).getAsString());
   }
 
   @Test
@@ -47,10 +80,11 @@ class SnykLanguageServerTest extends LsBaseTest {
 
     Object output = snykStreamConnectionProvider.getInitializationOptions(null);
 
-    assertInstanceOf(Settings.class, output);
-    Settings settings = (Settings) output;
-    assertNotNull(settings.getTrustedFolders());
-    assertEquals(0, settings.getTrustedFolders().length);
+    assertInstanceOf(JsonElement.class, output);
+    JsonObject root = ((JsonElement) output).getAsJsonObject();
+    var foldersArray = root.getAsJsonArray("trustedFolders");
+    assertNotNull(foldersArray);
+    assertEquals(0, foldersArray.size());
   }
 
   @Test
@@ -87,4 +121,5 @@ class SnykLanguageServerTest extends LsBaseTest {
 
     assertEquals(existingBinary.getAbsolutePath(), result);
   }
+
 }

--- a/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
@@ -121,5 +121,4 @@ class SnykLanguageServerTest extends LsBaseTest {
 
     assertEquals(existingBinary.getAbsolutePath(), result);
   }
-
 }

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -8,6 +8,7 @@ import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_PARAMS_TO_DISP
 import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_STATE_IN_PROGRESS;
 import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_STATE_SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -54,8 +55,10 @@ import io.snyk.languageserver.ScanInProgressKey;
 import io.snyk.languageserver.ScanState;
 import io.snyk.languageserver.SnykIssueCache;
 import io.snyk.languageserver.protocolextension.messageObjects.HasAuthenticatedParam;
+import io.snyk.languageserver.protocolextension.messageObjects.LspConfigurationParam;
 import io.snyk.languageserver.protocolextension.messageObjects.SnykScanParam;
 import io.snyk.languageserver.protocolextension.messageObjects.SnykTrustedFoldersParams;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.languageserver.protocolextension.messageObjects.scanResults.AdditionalData;
 import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue;
 
@@ -563,4 +566,309 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 	private AdditionalData getSecurityIssue() {
 		return Instancio.of(AdditionalData.class).create();
 	}
+
+	@Test
+	void snykConfigurationPersistsGlobalSettings() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"api_endpoint": {
+							"value": "https://custom.snyk.io",
+							"changed": true,
+							"source": "cli",
+							"originScope": "machine",
+							"isLocked": false
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("https://custom.snyk.io", pref.getPref(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	void snykConfigurationStoresFolderConfigs() {
+		var gson = new com.google.gson.Gson();
+		var folderSettings = new FolderConfigSettings();
+		FolderConfigSettings.setInstance(folderSettings);
+
+		String json = """
+				{
+					"folderConfigs": [
+						{
+							"folderPath": "/tmp/project1",
+							"settings": {
+								"base_branch": {
+									"value": "main"
+								}
+							}
+						}
+					]
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("main", folderSettings.getBaseBranch("/tmp/project1"));
+	}
+
+	@Test
+	void snykConfigurationHandlesBothGlobalAndFolder() {
+		var gson = new com.google.gson.Gson();
+		var folderSettings = new FolderConfigSettings();
+		FolderConfigSettings.setInstance(folderSettings);
+
+		String json = """
+				{
+					"settings": {
+						"api_endpoint": {
+							"value": "https://both.snyk.io"
+						}
+					},
+					"folderConfigs": [
+						{
+							"folderPath": "/tmp/project2",
+							"settings": {
+								"preferred_org": {
+									"value": "my-org"
+								}
+							}
+						}
+					]
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("https://both.snyk.io", pref.getPref(Preferences.ENDPOINT_KEY));
+		assertEquals("my-org", folderSettings.getPreferredOrg("/tmp/project2"));
+	}
+
+	@Test
+	void snykConfigurationReplacesExistingFolderConfigs() {
+		var gson = new com.google.gson.Gson();
+		var folderSettings = new FolderConfigSettings();
+		FolderConfigSettings.setInstance(folderSettings);
+
+		// First notification
+		String json1 = """
+				{
+					"folderConfigs": [
+						{
+							"folderPath": "/tmp/project1",
+							"settings": { "base_branch": { "value": "main" } }
+						}
+					]
+				}
+				""";
+		LspConfigurationParam param1 = gson.fromJson(json1, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param1);
+
+		assertEquals("main", folderSettings.getBaseBranch("/tmp/project1"));
+
+		// Second notification replaces all
+		String json2 = """
+				{
+					"folderConfigs": [
+						{
+							"folderPath": "/tmp/project2",
+							"settings": { "base_branch": { "value": "develop" } }
+						}
+					]
+				}
+				""";
+		LspConfigurationParam param2 = gson.fromJson(json2, LspConfigurationParam.class);
+		cut.snykConfiguration(param2);
+
+		// project1 should be gone
+		assertEquals("", folderSettings.getBaseBranch("/tmp/project1"));
+		assertEquals("develop", folderSettings.getBaseBranch("/tmp/project2"));
+	}
+
+	@Test
+	void snykConfigurationConvertsScanningModeAutomaticToBoolean() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"scan_automatic": {
+							"value": "automatic"
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("true", pref.getPref(Preferences.SCANNING_MODE_AUTOMATIC));
+	}
+
+	@Test
+	void snykConfigurationConvertsScanningModeManualToBoolean() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"scan_automatic": {
+							"value": "manual"
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("false", pref.getPref(Preferences.SCANNING_MODE_AUTOMATIC));
+	}
+
+	@Test
+	void snykConfigurationConvertsJsonBooleanToString() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"snyk_code_enabled": {
+							"value": true
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("true", pref.getPref(Preferences.ACTIVATE_SNYK_CODE_SECURITY));
+	}
+
+	@Test
+	void snykConfigurationDoesNotMarkSettingsAsExplicitlyChanged() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"api_endpoint": {
+							"value": "https://ls-pushed.snyk.io",
+							"changed": true
+						},
+						"snyk_oss_enabled": {
+							"value": "true",
+							"changed": false
+						},
+						"cli_insecure": {
+							"value": "false",
+							"changed": false
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		// Inbound settings use prefs.store(), not storeAndTrackChange,
+		// so they should NOT be marked as explicitly changed by the user
+		assertFalse(pref.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertFalse(pref.isExplicitlyChanged(Preferences.ACTIVATE_SNYK_OPEN_SOURCE));
+		assertFalse(pref.isExplicitlyChanged(Preferences.INSECURE_KEY));
+	}
+
+	@Test
+	void snykConfigurationHandlesEmptyPayload() {
+		var gson = new com.google.gson.Gson();
+		LspConfigurationParam param = gson.fromJson("{}", LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		// Should not throw
+		cut.snykConfiguration(param);
+	}
+
+	@Test
+	void snykConfigurationNeverThrows() {
+		cut = new SnykExtendedLanguageClient();
+		// null param should not throw
+		cut.snykConfiguration(null);
+	}
+
+	@Test
+	void snykConfigurationPersistsSnykSecretsEnabled() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"snyk_secrets_enabled": {
+							"value": true
+						}
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("true", pref.getPref(Preferences.ACTIVATE_SNYK_SECRETS));
+	}
+
+	@Test
+	void snykConfigurationPersistsAdditionalRegistryKeys() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"send_error_reports": { "value": "true" },
+						"automatic_download": { "value": "false" },
+						"proxy_insecure": { "value": "true" },
+						"authentication_method": { "value": "token" },
+						"scan_net_new": { "value": "true" }
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("true", pref.getPref(Preferences.SEND_ERROR_REPORTS));
+		assertEquals("false", pref.getPref(Preferences.MANAGE_BINARIES_AUTOMATICALLY));
+		assertEquals("true", pref.getPref(Preferences.INSECURE_KEY));
+		assertEquals("token", pref.getPref(Preferences.AUTHENTICATION_METHOD));
+		assertEquals("true", pref.getPref(Preferences.ENABLE_DELTA));
+	}
+
+	@Test
+	void snykConfigurationSkipsAlwaysFixedEntries() {
+		var gson = new com.google.gson.Gson();
+		// automatic_authentication and trust_enabled are always-fixed — inbound values ignored
+		String json = """
+				{
+					"settings": {
+						"automatic_authentication": { "value": "true" },
+						"trust_enabled": { "value": "false" }
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		// should not throw; fixed entries have no prefKey so are skipped
+		cut.snykConfiguration(param);
+	}
+
 }

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -853,6 +853,24 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 	}
 
 	@Test
+	void snykConfigurationNeverPersistsInboundToken() {
+		var gson = new com.google.gson.Gson();
+		String json = """
+				{
+					"settings": {
+						"token": { "value": "compromised-token" }
+					}
+				}
+				""";
+		LspConfigurationParam param = gson.fromJson(json, LspConfigurationParam.class);
+
+		cut = new SnykExtendedLanguageClient();
+		cut.snykConfiguration(param);
+
+		assertEquals("dummy", pref.getPref(Preferences.AUTH_TOKEN_KEY));
+	}
+
+	@Test
 	void snykConfigurationSkipsAlwaysFixedEntries() {
 		var gson = new com.google.gson.Gson();
 		// automatic_authentication and trust_enabled are always-fixed — inbound values ignored

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -703,7 +703,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 				{
 					"settings": {
 						"scan_automatic": {
-							"value": "automatic"
+							"value": true
 						}
 					}
 				}
@@ -723,7 +723,7 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 				{
 					"settings": {
 						"scan_automatic": {
-							"value": "manual"
+							"value": false
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

Second of three PRs splitting `feat/IDE-1652`. Wires up the new LS settings architecture introduced in PR #394. Legacy POJOs (`Settings`, `FolderConfig`, `FolderConfigs`, `FolderConfigsParam`, `IdeConfigData`) are left on disk as dead code — PR #393 deletes them.

- **`FolderConfigSettings`** — per-project store for folder-scoped LS config with explicit change tracking (`storeAndTrackChange`) and batch-flush to `Preferences` on save
- **`LsConfigurationUpdater`** — rewritten to build `LspConfigurationParam` via `LsSettingsRegistry`; replaces legacy `getCurrentSettings()` / `Settings` path
- **`SnykLanguageServer.getInitializationOptions`** — calls `buildConfigurationParam()`, pre-serializes via `Gson.toJsonTree()` so LSP4J embeds JSON correctly for custom POJOs like `ConfigSetting`
- **`SnykExtendedLanguageClient`** — adds `$/snyk.configuration` notification handler (`persistGlobalSettings`) for enterprise config push; outbound path uses `LspConfigurationParam`
- **`LsConstants`** — renames `SNYK_FOLDER_CONFIG` → `SNYK_CONFIGURATION`
- **`Preferences`** — registry-driven defaults, explicit change set, new `storeAndTrackChange` / `getExplicitChanges` / `persistGlobalSettings` APIs; adds `EXPLICIT_CHANGES_KEY`
- **`ExecuteCommandBridge`** — delta for new settings bridge commands
- **`NativeProjectPropertyPage` / `TokenFieldEditor` / `PreferencesPage`** — migrated to `FolderConfigSettings` / `LsSettingsRegistry` so they compile until PR #393 removes them
- **UI callers** (`ReferenceChooserDialog`, `SnykToolView`, `SummaryBrowserHandler`, `BaseHandler`, `SnykWizard`) — migrated to `FolderConfigSettings`

## PR sequence

| PR | Scope |
|----|-------|
| [1/3 — PR #394](https://github.com/snyk/snyk-eclipse-plugin/pull/394) | Foundation: registry, protocol POJOs |
| **This PR (2/3)** | Wiring: inbound handler, outbound updater, folder settings store |
| [3/3] | HTML settings page migration |
| [PR #393](https://github.com/snyk/snyk-eclipse-plugin/pull/393) | All deletions: legacy POJOs + native UI |

## Test plan

- [ ] `./mvnw test -pl plugin,tests` passes
- [ ] `./mvnw pmd:check -pl plugin` — zero violations
- [ ] Smoke: LS starts, `getInitializationOptions` returns `JsonElement` with `settings` / `folderConfigs` / `integrationName` / `requiredProtocolVersion` keys