### PR TITLE
feat(IDE-1652): migrate HTML settings page onto FolderConfigSettings + ExecuteCommandBridge (3/3)

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -160,12 +160,22 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
           .replace("{{CLI_PATH}}", htmlAttr(prefs.getCliPath()))
           .replace(
               "{{CHANNEL_STABLE_SELECTED}}",
-              "stable".equals(prefs.getReleaseChannel()) ? "selected" : "")
+              Preferences.RELEASE_CHANNEL_STABLE.equals(prefs.getReleaseChannel()) ? "selected" : "")
           .replace(
-              "{{CHANNEL_RC_SELECTED}}", "rc".equals(prefs.getReleaseChannel()) ? "selected" : "")
+              "{{CHANNEL_RC_SELECTED}}",
+              Preferences.RELEASE_CHANNEL_RC.equals(prefs.getReleaseChannel()) ? "selected" : "")
           .replace(
               "{{CHANNEL_PREVIEW_SELECTED}}",
-              "preview".equals(prefs.getReleaseChannel()) ? "selected" : "")
+              Preferences.RELEASE_CHANNEL_PREVIEW.equals(prefs.getReleaseChannel()) ? "selected" : "")
+          .replace(
+              "{{CHANNEL_CUSTOM_SELECTED}}",
+              isCustomChannel(prefs.getReleaseChannel()) ? "selected" : "")
+          .replace(
+              "{{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}}",
+              isCustomChannel(prefs.getReleaseChannel()) ? "" : "hidden")
+          .replace(
+              "{{CLI_RELEASE_CHANNEL_CUSTOM_VALUE}}",
+              isCustomChannel(prefs.getReleaseChannel()) ? htmlAttr(prefs.getReleaseChannel()) : "")
           .replace("{{INSECURE_CHECKED}}", prefs.isInsecure() ? "checked" : "");
     } catch (IOException e) {
       SnykLogger.logError(e);
@@ -275,6 +285,13 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
       }
       return config;
     });
+  }
+
+  private static boolean isCustomChannel(String channel) {
+    return channel != null
+        && !Preferences.RELEASE_CHANNEL_STABLE.equals(channel)
+        && !Preferences.RELEASE_CHANNEL_RC.equals(channel)
+        && !Preferences.RELEASE_CHANNEL_PREVIEW.equals(channel);
   }
 
   /** Escapes for double-quoted HTML attribute context only. Do not use in JS/URL contexts. */

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -37,6 +37,7 @@ import org.eclipse.ui.commands.ICommandService;
 
 public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
 
+  private static final String SELECTED = "selected";
   private static volatile HTMLSettingsPreferencePage instance;
   private Browser browser;
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -160,16 +161,16 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
           .replace("{{CLI_PATH}}", htmlAttr(prefs.getCliPath()))
           .replace(
               "{{CHANNEL_STABLE_SELECTED}}",
-              Preferences.RELEASE_CHANNEL_STABLE.equals(prefs.getReleaseChannel()) ? "selected" : "")
+              Preferences.RELEASE_CHANNEL_STABLE.equals(prefs.getReleaseChannel()) ? SELECTED : "")
           .replace(
               "{{CHANNEL_RC_SELECTED}}",
-              Preferences.RELEASE_CHANNEL_RC.equals(prefs.getReleaseChannel()) ? "selected" : "")
+              Preferences.RELEASE_CHANNEL_RC.equals(prefs.getReleaseChannel()) ? SELECTED : "")
           .replace(
               "{{CHANNEL_PREVIEW_SELECTED}}",
-              Preferences.RELEASE_CHANNEL_PREVIEW.equals(prefs.getReleaseChannel()) ? "selected" : "")
+              Preferences.RELEASE_CHANNEL_PREVIEW.equals(prefs.getReleaseChannel()) ? SELECTED : "")
           .replace(
               "{{CHANNEL_CUSTOM_SELECTED}}",
-              isCustomChannel(prefs.getReleaseChannel()) ? "selected" : "")
+              isCustomChannel(prefs.getReleaseChannel()) ? SELECTED : "")
           .replace(
               "{{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}}",
               isCustomChannel(prefs.getReleaseChannel()) ? "" : "hidden")

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -247,9 +247,18 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
           continue;
         }
         if (LsFolderSettingsKeys.SCAN_COMMAND_CONFIG.equals(key)) {
-          Map<String, ScanCommandConfig> scanCommandMap = objectMapper.convertValue(
-              node, objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, ScanCommandConfig.class));
-          config = config.withSetting(key, scanCommandMap, true);
+          if (!node.isObject()) {
+            SnykLogger.logInfo("Skipping non-object scan_command_config for folder " + pathStr);
+            continue;
+          }
+          try {
+            Map<String, ScanCommandConfig> scanCommandMap = objectMapper.convertValue(
+                node, objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, ScanCommandConfig.class));
+            config = config.withSetting(key, scanCommandMap, true);
+          } catch (IllegalArgumentException e) {
+            SnykLogger.logError(e);
+            continue;
+          }
         } else if (node.isArray()) {
           List<String> list = StreamSupport.stream(node.spliterator(), false)
               .filter(el -> !el.isNull())

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -268,6 +268,8 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
         } else if (node.isBoolean()) {
           config = config.withSetting(key, node.booleanValue(), true);
         } else {
+          SnykLogger.logInfo("processFolderConfig: storing unknown field type as text for key=" + key
+              + " jsonType=" + node.getNodeType());
           config = config.withSetting(key, node.asText(), true);
         }
       }
@@ -275,6 +277,7 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
     });
   }
 
+  /** Escapes for double-quoted HTML attribute context only. Do not use in JS/URL contexts. */
   private static String htmlAttr(String v) {
     if (v == null) return "";
     return v.replace("&", "&amp;").replace("\"", "&quot;").replace("<", "&lt;");

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -156,8 +156,8 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
           .replace("{{MANAGE_BINARIES_CHECKED}}", prefs.isManagedBinaries() ? "checked" : "")
           .replace(
               "{{CLI_BASE_DOWNLOAD_URL}}",
-              prefs.getPref(Preferences.CLI_BASE_URL, "https://downloads.snyk.io"))
-          .replace("{{CLI_PATH}}", prefs.getCliPath())
+              htmlAttr(prefs.getPref(Preferences.CLI_BASE_URL, "https://downloads.snyk.io")))
+          .replace("{{CLI_PATH}}", htmlAttr(prefs.getCliPath()))
           .replace(
               "{{CHANNEL_STABLE_SELECTED}}",
               "stable".equals(prefs.getReleaseChannel()) ? "selected" : "")
@@ -273,6 +273,11 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
       }
       return config;
     });
+  }
+
+  private static String htmlAttr(String v) {
+    if (v == null) return "";
+    return v.replace("&", "&amp;").replace("\"", "&quot;").replace("<", "&lt;");
   }
 
   private void refreshToolbarUI() {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -1,24 +1,27 @@
 package io.snyk.eclipse.plugin.preferences;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.snyk.eclipse.plugin.html.BaseHtmlProvider;
 import io.snyk.eclipse.plugin.html.ExecuteCommandBridge;
-import io.snyk.eclipse.plugin.properties.FolderConfigs;
+import io.snyk.eclipse.plugin.properties.FolderConfigSettings;
 import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.eclipse.plugin.views.snyktoolview.handlers.IHandlerCommands;
+import io.snyk.languageserver.LsFolderSettingsKeys;
+import io.snyk.languageserver.LsSettingsRegistry;
+import io.snyk.languageserver.LsSettingsRegistry.Entry;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
-import io.snyk.languageserver.protocolextension.messageObjects.FolderConfig;
 import io.snyk.languageserver.protocolextension.messageObjects.ScanCommandConfig;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
@@ -172,136 +175,95 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
 
   private void parseAndSaveConfig(String jsonString) {
     try {
-      IdeConfigData config = objectMapper.readValue(jsonString, IdeConfigData.class);
+      JsonNode root = objectMapper.readTree(jsonString);
       Preferences prefs = Preferences.getInstance();
 
-      boolean isFallback = Boolean.TRUE.equals(config.isFallbackForm());
+      JsonNode fallbackNode = root.get("isFallbackForm");
+      boolean isFallback = fallbackNode != null && fallbackNode.booleanValue();
 
-      // CLI Settings - always persist for both fallback and full forms
-      prefs.store(Preferences.CLI_PATH, String.valueOf(config.cliPath()));
-      prefs.store(
-          Preferences.MANAGE_BINARIES_AUTOMATICALLY,
-          String.valueOf(config.manageBinariesAutomatically()));
-      prefs.store(Preferences.CLI_BASE_URL, String.valueOf(config.cliBaseDownloadURL()));
-      prefs.store(Preferences.RELEASE_CHANNEL, String.valueOf(config.cliReleaseChannel()));
-      prefs.store(Preferences.INSECURE_KEY, String.valueOf(config.insecure()));
+      for (Entry entry : LsSettingsRegistry.ENTRIES.values()) {
+        if (entry.prefKey == null) continue;
+        if (isFallback && !entry.useInFallbackForm) continue;
 
-      // Only persist non-CLI fields if not fallback form
+        JsonNode n = root.get(entry.lsKey.key);
+        if (n == null) {
+          // absent — form didn't send this key, leave tracking untouched
+        } else if (n.isNull()) {
+          prefs.clearExplicitlyChangedNoFlush(entry.prefKey);
+        } else if (entry.formDeserializer != null) {
+          prefs.store(entry.prefKey, entry.formDeserializer.apply(n));
+          prefs.markExplicitlyChangedNoFlush(entry.prefKey);
+        } else {
+          prefs.store(entry.prefKey, nodeToString(n));
+          prefs.markExplicitlyChangedNoFlush(entry.prefKey);
+        }
+      }
+      prefs.flushExplicitChanges();
+
       if (!isFallback) {
-        // Scan Settings
-        prefs.store(
-            Preferences.ACTIVATE_SNYK_OPEN_SOURCE,
-            String.valueOf(config.activateSnykOpenSource()));
-        prefs.store(
-            Preferences.ACTIVATE_SNYK_CODE_SECURITY, String.valueOf(config.activateSnykCode()));
-        prefs.store(Preferences.ACTIVATE_SNYK_IAC, String.valueOf(config.activateSnykIac()));
-
-        if (config.scanningMode() != null) {
-          boolean isAutomatic = "auto".equals(config.scanningMode());
-          prefs.store(Preferences.SCANNING_MODE_AUTOMATIC, String.valueOf(isAutomatic));
-        }
-
-        // Issue View Settings
-        if (config.issueViewOptions() != null) {
-          IdeConfigData.IssueViewOptions options = config.issueViewOptions();
-          prefs.store(
-              Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES, String.valueOf(options.openIssues()));
-          prefs.store(
-              Preferences.FILTER_IGNORES_SHOW_IGNORED_ISSUES,
-              String.valueOf(options.ignoredIssues()));
-        }
-        prefs.store(Preferences.ENABLE_DELTA, String.valueOf(config.enableDeltaFindings()));
-
-        // Authentication Settings
-        if (config.authenticationMethod() != null) {
-          prefs.store(Preferences.AUTHENTICATION_METHOD, config.authenticationMethod());
-        }
-
-        // Connection Settings
-        prefs.store(Preferences.ENDPOINT_KEY, String.valueOf(config.endpoint()));
-        prefs.store(Preferences.AUTH_TOKEN_KEY, String.valueOf(config.token()));
-        if (config.organization() != null) {
-          prefs.store(Preferences.ORGANIZATION_KEY, String.valueOf(config.organization()));
-        }
-
-        // Trusted Folders
-        if (config.trustedFolders() != null) {
-          String trustedFoldersString = String.join(File.pathSeparator, config.trustedFolders());
-          prefs.store(Preferences.TRUSTED_FOLDERS, trustedFoldersString);
-        }
-
-        // Filter Settings
-        if (config.filterSeverity() != null) {
-          IdeConfigData.FilterSeverity severity = config.filterSeverity();
-          prefs.store(Preferences.FILTER_SHOW_CRITICAL, String.valueOf(severity.critical()));
-          prefs.store(Preferences.FILTER_SHOW_HIGH, String.valueOf(severity.high()));
-          prefs.store(Preferences.FILTER_SHOW_MEDIUM, String.valueOf(severity.medium()));
-          prefs.store(Preferences.FILTER_SHOW_LOW, String.valueOf(severity.low()));
-        }
-        prefs.store(
-            Preferences.RISK_SCORE_THRESHOLD, String.valueOf(config.riskScoreThreshold()));
-
-        // Folder Configs
-        if (config.folderConfigs() != null && !config.folderConfigs().isEmpty()) {
-          for (IdeConfigData.FolderConfigData folderConfigData : config.folderConfigs()) {
-            processFolderConfig(folderConfigData);
+        // Folder configs.
+        JsonNode folderConfigsNode = root.get("folderConfigs");
+        if (folderConfigsNode != null && folderConfigsNode.isArray()) {
+          for (JsonNode folderNode : folderConfigsNode) {
+            processFolderConfig(folderNode);
           }
         }
       }
 
-      // Refresh toolbar UI to reflect changes made in HTML settings
+      // Refresh toolbar UI to reflect changes made in HTML settings.
       refreshToolbarUI();
     } catch (JsonProcessingException e) {
       SnykLogger.logError(e);
     }
   }
 
-  private void processFolderConfig(IdeConfigData.FolderConfigData folderConfigData) {
-    if (folderConfigData.folderPath() == null) {
-      return;
+  private static String nodeToString(JsonNode node) {
+    if (node.isBoolean()) {
+      return node.asText(); // "true" or "false"
     }
-
-    FolderConfig folderConfig =
-        FolderConfigs.getInstance().getFolderConfig(Paths.get(folderConfigData.folderPath()));
-
-    if (folderConfigData.preferredOrg() != null) {
-      folderConfig.setPreferredOrg(folderConfigData.preferredOrg());
+    if (node.isNumber()) {
+      double d = node.asDouble();
+      if (d == Math.floor(d) && !Double.isInfinite(d)) {
+        return String.valueOf((long) d);
+      }
+      return String.valueOf(d);
     }
-    if (folderConfigData.autoDeterminedOrg() != null) {
-      folderConfig.setAutoDeterminedOrg(folderConfigData.autoDeterminedOrg());
-    }
-    if (folderConfigData.orgSetByUser() != null) {
-      folderConfig.setOrgSetByUser(folderConfigData.orgSetByUser());
-    }
-    if (folderConfigData.additionalEnv() != null) {
-      folderConfig.setAdditionalEnv(folderConfigData.additionalEnv());
-    }
-    if (folderConfigData.additionalParameters() != null) {
-      folderConfig.setAdditionalParameters(folderConfigData.additionalParameters());
-    }
-    if (folderConfigData.scanCommandConfig() != null) {
-      Map<String, ScanCommandConfig> targetConfigMap =
-          convertScanCommandConfig(folderConfigData.scanCommandConfig());
-      folderConfig.setScanCommandConfig(targetConfigMap);
-    }
+    return node.asText();
   }
 
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  private Map<String, ScanCommandConfig> convertScanCommandConfig(
-      Map<String, IdeConfigData.ScanCommandConfigData> sourceConfigMap) {
-    Map<String, ScanCommandConfig> targetConfigMap = new HashMap<>();
-    for (Map.Entry<String, IdeConfigData.ScanCommandConfigData> entry :
-        sourceConfigMap.entrySet()) {
-      IdeConfigData.ScanCommandConfigData configData = entry.getValue();
-      ScanCommandConfig scanCommandConfig =
-          new ScanCommandConfig(
-              configData.preScanCommand(),
-              Boolean.TRUE.equals(configData.preScanOnlyReferenceFolder()),
-              configData.postScanCommand(),
-              Boolean.TRUE.equals(configData.postScanOnlyReferenceFolder()));
-      targetConfigMap.put(entry.getKey(), scanCommandConfig);
+  private void processFolderConfig(JsonNode folderNode) {
+    JsonNode pathNode = folderNode.get("folderPath");
+    if (pathNode == null || pathNode.isNull()) {
+      return;
     }
-    return targetConfigMap;
+    String pathStr = pathNode.asText();
+    FolderConfigSettings.getInstance().computeFolderConfig(pathStr, config -> {
+      var fields = folderNode.fields();
+      while (fields.hasNext()) {
+        var field = fields.next();
+        String key = field.getKey();
+        JsonNode node = field.getValue();
+        if ("folderPath".equals(key) || node.isNull()) {
+          continue;
+        }
+        if (LsFolderSettingsKeys.SCAN_COMMAND_CONFIG.equals(key)) {
+          Map<String, ScanCommandConfig> scanCommandMap = objectMapper.convertValue(
+              node, objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, ScanCommandConfig.class));
+          config = config.withSetting(key, scanCommandMap, true);
+        } else if (node.isArray()) {
+          List<String> list = StreamSupport.stream(node.spliterator(), false)
+              .filter(el -> !el.isNull())
+              .map(JsonNode::asText)
+              .collect(Collectors.toList());
+          config = config.withSetting(key, list, true);
+        } else if (node.isBoolean()) {
+          config = config.withSetting(key, node.booleanValue(), true);
+        } else {
+          config = config.withSetting(key, node.asText(), true);
+        }
+      }
+      return config;
+    });
   }
 
   private void refreshToolbarUI() {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/Preferences.java
@@ -86,6 +86,9 @@ public class Preferences {
 	public static final String DEFAULT_ENDPOINT = "https://api.snyk.io";
 	public static final String DEVICE_ID = "deviceId";
 	public static final String RELEASE_CHANNEL = "releaseChannel";
+	public static final String RELEASE_CHANNEL_STABLE = "stable";
+	public static final String RELEASE_CHANNEL_RC = "rc";
+	public static final String RELEASE_CHANNEL_PREVIEW = "preview";
 	public static final String USE_LS_HTML_CONFIG_DIALOG = "useLsHtmlConfigDialog";
 	public static final String EXPLICIT_CHANGES_KEY = "explicitChanges";
 
@@ -342,7 +345,7 @@ public class Preferences {
 	}
 
 	public final String getReleaseChannel() {
-		return getPref(RELEASE_CHANNEL, "stable");
+		return getPref(RELEASE_CHANNEL, RELEASE_CHANNEL_STABLE);
 	}
 
 	public void setTest(boolean b) {

--- a/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
@@ -202,7 +202,7 @@ public final class LsSettingsRegistry {
                     }
                     return sb.toString();
                 }, false));
-        entries.put(LsKey.CLI_RELEASE_CHANNEL,    Entry.fallback(LsKey.CLI_RELEASE_CHANNEL, Preferences.RELEASE_CHANNEL, "stable"));
+        entries.put(LsKey.CLI_RELEASE_CHANNEL,    Entry.fallback(LsKey.CLI_RELEASE_CHANNEL, Preferences.RELEASE_CHANNEL, Preferences.RELEASE_CHANNEL_STABLE));
 
         ENTRIES = Collections.unmodifiableMap(entries);
 

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -448,10 +448,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		for (var entry : settings.entrySet()) {
 			try {
 				var registryEntry = LsSettingsRegistry.BY_LS_KEY.get(entry.getKey());
-				if (registryEntry == null || registryEntry.prefKey == null) {
-					continue;
-				}
-				if (registryEntry.lsKey == LsKey.TOKEN) {
+				if (registryEntry == null || registryEntry.prefKey == null || registryEntry.encrypted) {
 					continue;
 				}
 				var setting = entry.getValue();

--- a/tests/src/test/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePageTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePageTest.java
@@ -33,7 +33,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesCliPath() throws Exception {
-		String json = "{\"cliPath\": \"/usr/local/bin/snyk\"}";
+		String json = "{\"cli_path\": \"/usr/local/bin/snyk\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -42,7 +42,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesManageBinariesAutomatically() throws Exception {
-		String json = "{\"manageBinariesAutomatically\": false}";
+		String json = "{\"automatic_download\": false}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -51,7 +51,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesCliBaseDownloadURL() throws Exception {
-		String json = "{\"cliBaseDownloadURL\": \"https://custom.downloads.snyk.io\"}";
+		String json = "{\"binary_base_url\": \"https://custom.downloads.snyk.io\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -60,7 +60,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesCliReleaseChannel() throws Exception {
-		String json = "{\"cliReleaseChannel\": \"preview\"}";
+		String json = "{\"cli_release_channel\": \"preview\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -69,7 +69,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesActivateSnykOpenSource() throws Exception {
-		String json = "{\"activateSnykOpenSource\": false}";
+		String json = "{\"snyk_oss_enabled\": false}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -78,7 +78,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesActivateSnykCode() throws Exception {
-		String json = "{\"activateSnykCode\": true}";
+		String json = "{\"snyk_code_enabled\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -87,7 +87,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesActivateSnykIac() throws Exception {
-		String json = "{\"activateSnykIac\": false}";
+		String json = "{\"snyk_iac_enabled\": false}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -105,7 +105,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesEndpoint() throws Exception {
-		String json = "{\"endpoint\": \"https://custom.api.snyk.io\"}";
+		String json = "{\"api_endpoint\": \"https://custom.api.snyk.io\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -114,7 +114,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesInsecure() throws Exception {
-		String json = "{\"insecure\": true}";
+		String json = "{\"proxy_insecure\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -123,7 +123,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesScanningModeAuto() throws Exception {
-		String json = "{\"scanningMode\": \"auto\"}";
+		String json = "{\"scan_automatic\": \"auto\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -132,7 +132,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesScanningModeManual() throws Exception {
-		String json = "{\"scanningMode\": \"manual\"}";
+		String json = "{\"scan_automatic\": \"manual\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -141,7 +141,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesAuthenticationMethodOAuth() throws Exception {
-		String json = "{\"authenticationMethod\": \"oauth\"}";
+		String json = "{\"authentication_method\": \"oauth\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -150,7 +150,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesAuthenticationMethodToken() throws Exception {
-		String json = "{\"authenticationMethod\": \"token\"}";
+		String json = "{\"authentication_method\": \"token\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -159,7 +159,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesSeverityFilters() throws Exception {
-		String json = "{\"filterSeverity\": {\"critical\": false, \"high\": true, \"medium\": false, \"low\": true}}";
+		String json = "{\"severity_filter_critical\": false, \"severity_filter_high\": true, \"severity_filter_medium\": false, \"severity_filter_low\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -171,7 +171,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesIssueViewOptions() throws Exception {
-		String json = "{\"issueViewOptions\": {\"openIssues\": false, \"ignoredIssues\": true}}";
+		String json = "{\"issue_view_open_issues\": false, \"issue_view_ignored_issues\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -181,7 +181,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesEnableDeltaFindings() throws Exception {
-		String json = "{\"enableDeltaFindings\": true}";
+		String json = "{\"scan_net_new\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -190,7 +190,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_savesRiskScoreThreshold() throws Exception {
-		String json = "{\"riskScoreThreshold\": 200}";
+		String json = "{\"risk_score_threshold\": 200}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -199,7 +199,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_handlesMultipleSettings() throws Exception {
-		String json = "{\"cliPath\": \"/custom/path\", \"organization\": \"test-org\", \"insecure\": true}";
+		String json = "{\"cli_path\": \"/custom/path\", \"organization\": \"test-org\", \"proxy_insecure\": true}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -210,7 +210,7 @@ class HTMLSettingsPreferencePageTest {
 
 	@Test
 	void parseAndSaveConfig_ignoresUnknownFields() throws Exception {
-		String json = "{\"unknownField\": \"value\", \"cliPath\": \"/valid/path\"}";
+		String json = "{\"unknownField\": \"value\", \"cli_path\": \"/valid/path\"}";
 
 		invokeParseAndSaveConfig(json);
 
@@ -224,6 +224,58 @@ class HTMLSettingsPreferencePageTest {
 		invokeParseAndSaveConfig(json);
 
 		// Should not throw, preferences should remain unchanged
+	}
+
+	@Test
+	void parseAndSaveConfig_nullEndpointClearsExplicitOverride() throws Exception {
+		// User previously set endpoint
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://user-override.snyk.io");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+
+		// LS form sends null for endpoint (user reset it)
+		String json = "{\"api_endpoint\": null}";
+		invokeParseAndSaveConfig(json);
+
+		// Override should be cleared
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+	}
+
+	@Test
+	void parseAndSaveConfig_nullOrganizationClearsExplicitOverride() throws Exception {
+		prefs.storeAndTrackChange(Preferences.ORGANIZATION_KEY, "my-org");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+
+		String json = "{\"organization\": null}";
+		invokeParseAndSaveConfig(json);
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+	}
+
+	@Test
+	void parseAndSaveConfig_nullCliPathClearsExplicitOverride() throws Exception {
+		prefs.storeAndTrackChange(Preferences.CLI_PATH, "/custom/cli");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.CLI_PATH));
+
+		String json = "{\"cli_path\": null}";
+		invokeParseAndSaveConfig(json);
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.CLI_PATH));
+	}
+
+	@Test
+	void parseAndSaveConfig_mixedNullAndValueFields() throws Exception {
+		prefs.storeAndTrackChange(Preferences.ENDPOINT_KEY, "https://custom.snyk.io");
+		prefs.storeAndTrackChange(Preferences.ORGANIZATION_KEY, "old-org");
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+
+		// Endpoint reset (null), organization changed to new value
+		String json = "{\"api_endpoint\": null, \"organization\": \"new-org\"}";
+		invokeParseAndSaveConfig(json);
+
+		assertFalse(prefs.isExplicitlyChanged(Preferences.ENDPOINT_KEY));
+		assertTrue(prefs.isExplicitlyChanged(Preferences.ORGANIZATION_KEY));
+		assertEquals("new-org", prefs.getPref(Preferences.ORGANIZATION_KEY));
 	}
 
 	private void invokeParseAndSaveConfig(String json) throws Exception {


### PR DESCRIPTION
## Summary

Third and final new PR in the `feat/IDE-1652` split. Migrates the HTML settings page to the new store introduced in PR #395. After this lands, all legacy POJOs and native UI shells are dead code with no callers — PR #393 deletes them.

- **`HTMLSettingsPreferencePage`** — rewired to read/write settings via `FolderConfigSettings` and `LsSettingsRegistry` instead of the legacy `Settings` / `IdeConfigData` path; bridges auth and settings updates through `ExecuteCommandBridge`
- **`settings-fallback.html`** — synced from `snyk-ls` shared IDE resources with updated JS wiring for new settings bridge commands
- **`HTMLSettingsPreferencePageTest`** — updated to cover new wiring

## Dead code after this PR (deleted by PR #393)

`Settings`, `FolderConfig`, `FolderConfigsParam`, `FolderConfigs`, `IdeConfigData`, `NativeProjectPropertyPage`, `PreferencesPage`, `TokenFieldEditor`, `LsRuntimeEnvironment` env-var path, `Preferences` native getters.

## PR sequence

| PR | Scope |
|----|-------|
| [1/3 — PR #394](https://github.com/snyk/snyk-eclipse-plugin/pull/394) | Foundation: registry, protocol POJOs |
| [2/3 — PR #395](https://github.com/snyk/snyk-eclipse-plugin/pull/395) | Wiring: inbound handler, outbound updater, folder settings store |
| **This PR (3/3)** | HTML settings page migration |
| [PR #393](https://github.com/snyk/snyk-eclipse-plugin/pull/393) | All deletions: legacy POJOs + native UI |

## Test plan

- [ ] `./mvnw test -pl plugin,tests` passes
- [ ] `./mvnw pmd:check -pl plugin` — zero violations
- [ ] Smoke: Eclipse Snyk preferences open (HTML page), auth flow completes, settings persist across restart