### PR TITLE
feat(html-settings): wire user_settings_path into Eclipse plugin [IDE-2037]

### DIFF
--- a/plugin/src/main/java/io/snyk/languageserver/LsKey.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsKey.java
@@ -18,6 +18,7 @@ public enum LsKey {
     ENABLE_TELEMETRY("enableTelemetry"),
     MANAGE_BINARIES_AUTOMATICALLY("automatic_download"),
     CLI_PATH("cli_path"),
+    USER_SETTINGS_PATH("user_settings_path"),
     CLI_BASE_DOWNLOAD_URL("binary_base_url"),
     AUTOMATIC_AUTHENTICATION("automatic_authentication"),
     AUTHENTICATION_METHOD("authentication_method"),

--- a/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
@@ -135,6 +135,7 @@ public final class LsSettingsRegistry {
         entries.put(LsKey.SEND_ERROR_REPORTS,     Entry.simple(LsKey.SEND_ERROR_REPORTS, Preferences.SEND_ERROR_REPORTS, ""));
         entries.put(LsKey.MANAGE_BINARIES_AUTOMATICALLY, Entry.boolFallback(LsKey.MANAGE_BINARIES_AUTOMATICALLY, Preferences.MANAGE_BINARIES_AUTOMATICALLY, true));
         entries.put(LsKey.CLI_PATH,               Entry.fallback(LsKey.CLI_PATH, Preferences.CLI_PATH, ""));
+        entries.put(LsKey.USER_SETTINGS_PATH,     Entry.simple(LsKey.USER_SETTINGS_PATH, Preferences.PATH_KEY, ""));
         entries.put(LsKey.CLI_BASE_DOWNLOAD_URL,  Entry.fallback(LsKey.CLI_BASE_DOWNLOAD_URL, Preferences.CLI_BASE_URL, "https://downloads.snyk.io"));
         entries.put(LsKey.INSECURE,               Entry.boolFallback(LsKey.INSECURE, Preferences.INSECURE_KEY, false));
         entries.put(LsKey.ADDITIONAL_PARAMS,      Entry.simple(LsKey.ADDITIONAL_PARAMS, Preferences.ADDITIONAL_PARAMETERS, ""));

--- a/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/LsConfigurationUpdaterTest.java
@@ -267,6 +267,31 @@ class LsConfigurationUpdaterTest {
 	}
 
 	@Test
+	void testBuildConfigurationParam_userSettingsPath_outbound() {
+		setupPreferenceMock();
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertNotNull(param.getSettings().get(LsKey.USER_SETTINGS_PATH.key));
+		assertEquals("path", param.getSettings().get(LsKey.USER_SETTINGS_PATH.key).getValue());
+	}
+
+	@Test
+	void testBuildConfigurationParam_userSettingsPath_changedFlag() {
+		setupPreferenceMock();
+		when(preferenceMock.isExplicitlyChanged(Preferences.PATH_KEY)).thenReturn(true);
+
+		var param = new LsConfigurationUpdater().buildConfigurationParam();
+		assertTrue(param.getSettings().get(LsKey.USER_SETTINGS_PATH.key).getChanged());
+	}
+
+	@Test
+	void testLsSettingsRegistry_userSettingsPath_inboundRoundTrip() {
+		var entry = LsSettingsRegistry.BY_LS_KEY.get(LsKey.USER_SETTINGS_PATH.key);
+		assertNotNull(entry, "BY_LS_KEY must contain user_settings_path");
+		assertEquals(Preferences.PATH_KEY, entry.prefKey);
+		assertEquals("/usr/local/bin", entry.inboundDeserializer.apply("/usr/local/bin"));
+	}
+
+	@Test
 	void testBuildConfigurationParam_cliBaseDownloadUrlChangedFlag() {
 		setupPreferenceMock();
 		when(preferenceMock.isExplicitlyChanged(Preferences.CLI_BASE_URL)).thenReturn(true);


### PR DESCRIPTION
## Summary
<img width="1039" height="1064" alt="image" src="https://github.com/user-attachments/assets/4c4b4c00-524d-406c-a8c5-9275a3eb8ed6" />
<img width="1667" height="776" alt="image" src="https://github.com/user-attachments/assets/73a99b41-1679-45e0-bba7-4248bb6190f7" />

- Adds `USER_SETTINGS_PATH("user_settings_path")` to `LsKey` (next to `CLI_PATH`)
- Registers `Entry.simple(USER_SETTINGS_PATH, PATH_KEY, "")` in `LsSettingsRegistry`, wiring both directions:
  - **Outbound** (`LsConfigurationUpdater` iterates `ENTRIES`): sends `user_settings_path` in `didChangeConfiguration` with the changed flag
  - **Inbound** (`BY_LS_KEY` lookup): routes `$/snyk.configuration` updates back into `Preferences.PATH_KEY`

`LsConfigurationUpdater.java:72` (top-level `initializationOptions.path`) is untouched — both transports serve distinct lifecycle points; the duplicate write at init is idempotent.

## Migration

Zero-touch. Existing users already have `PATH_KEY` populated; the new registry entry means the value now also flows through `user_settings_path` in `didChangeConfiguration`. On first dialog open, the Path input pre-fills from the existing pref automatically.

## Changes

| File | Change |
|------|--------|
| `LsKey.java` | add `USER_SETTINGS_PATH("user_settings_path")` next to `CLI_PATH` |
| `LsSettingsRegistry.java` | add `Entry.simple(USER_SETTINGS_PATH, PATH_KEY, "")` |
| `LsConfigurationUpdaterTest.java` | outbound value, changed-flag, BY_LS_KEY round-trip tests |

## Test plan

- [ ] `mvn test` passes
- [ ] `LsConfigurationUpdaterTest` — 3 new tests green
- [ ] Manual: open HTML settings in Eclipse against snyk-ls PR #1299 build → Path field visible, value round-trips on save

## Related

- snyk-ls PR: https://github.com/snyk/snyk-ls/pull/1299
- Jira: [IDE-2037](https://snyksec.atlassian.net/browse/IDE-2037)

[IDE-2037]: https://snyksec.atlassian.net/browse/IDE-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ