### PR TITLE
fix: prevent Esc key from closing Eclipse settings page [IDE-1691]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePage.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.BrowserFunction;
+import org.eclipse.swt.events.TraverseListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -61,6 +62,9 @@ public class HTMLSettingsPreferencePage extends PreferencePage implements IWorkb
     container.setLayout(new FillLayout());
 
     browser = new Browser(container, SWT.WEBKIT);
+    browser.addTraverseListener(e -> {
+      if (e.detail == SWT.TRAVERSE_ESCAPE) e.doit = false;
+    });
     initializeBrowserFunctions();
     loadContent();
 


### PR DESCRIPTION
## Summary
- Add a `TraverseListener` on the embedded `Browser` widget in `HTMLSettingsPreferencePage` that consumes `SWT.TRAVERSE_ESCAPE`.

## Why
Without it, pressing Esc inside the HTML settings page bubbles up to the parent `PreferenceDialog` and dismisses the entire preference window — which is jarring when the user only meant to close a dropdown.

## Test plan
- [ ] Manual: open the Snyk settings preference page, focus inside the embedded browser, press Esc — dialog should stay open.

Jira: [IDE-1691](https://snyksec.atlassian.net/browse/IDE-1691)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-1691]: https://snyksec.atlassian.net/browse/IDE-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ