### PR TITLE
fix: use link color for AI Fix button in light themes [IDE-1252]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
@@ -90,9 +90,7 @@ public class CodeHtmlProvider extends BaseHtmlProvider {
 	// Make Generate AI fix / Apply fix buttons match the outlined Create-ignore
 	// style (transparent background, link-coloured border + text, fill on hover).
 	private String injectButtonOverride(String html, String linkColor, String onLinkColor) {
-		// CSP in details.html only allows styles with nonce 'ideNonce' or '{{.Nonce}}';
-		// without it the browser silently drops the override.
-		String override = "<style nonce=\"ideNonce\" id=\"snyk-eclipse-button-override\">"
+		String override = "<style id=\"snyk-eclipse-button-override\">"
 				+ "button.generate-ai-fix,button.sn-apply-fix{"
 				+ "background-color:transparent;"
 				+ "color:" + linkColor + ";"

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
@@ -62,52 +62,26 @@ public class CodeHtmlProvider extends BaseHtmlProvider {
 	public String replaceCssVariables(String html) {
 		String htmlStyled = super.replaceCssVariables(html);
 
-		String linkColor = super.getColorAsHex("org.eclipse.ui.editors.hyperlinkColor", "#4C8DEF");
-		String onLinkColor = super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR", "#FFFFFF");
-
 		// Replace CSS variables with actual color values
 		htmlStyled = htmlStyled.replace("var(--example-line-removed-color)",
 				super.getColorAsHex("DELETION_COLOR", "#ff0000"));
 		htmlStyled = htmlStyled.replace("var(--example-line-added-color)",
 				super.getColorAsHex("ADDITION_COLOR", "#00ff00"));
-		htmlStyled = htmlStyled.replace("var(--button-background-color)", linkColor);
-		htmlStyled = htmlStyled.replace("var(--button-text-color)", onLinkColor);
+		htmlStyled = htmlStyled.replace("var(--button-background-color)",
+				super.getColorAsHex("org.eclipse.ui.editors.hyperlinkColor", "#4C8DEF"));
+		htmlStyled = htmlStyled.replace("var(--button-text-color)",
+				super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR", "#F5F5F5"));
 		htmlStyled = htmlStyled.replace("var(--disabled-background-color)",
 				super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_OUTER_KEYLINE_COLOR", "#CCCCCC"));
-		htmlStyled = htmlStyled.replace("var(--vscode-input-border)", linkColor);
+		htmlStyled = htmlStyled.replace("var(--vscode-input-border)", super.getColorAsHex("BUTTON_COLOR", "#375578"));
 		htmlStyled = htmlStyled.replace("var(--warning-text)", super.getColorAsHex("WARNING_TEXT_COLOR", "#000000"));
 		htmlStyled = htmlStyled.replace("var(--warning-background)",
 				super.getColorAsHex("WARNING_BACKGROUND_COLOR", "#c8a000"));
-
-		htmlStyled = injectButtonOverride(htmlStyled, linkColor, onLinkColor);
 
 		String htmlWithScripts = replaceAIFixScripts(htmlStyled);
 		String htmlWithIgnoreRequest = replaceIgnoreRequestScript(htmlWithScripts);
 
 		return htmlWithIgnoreRequest;
-	}
-
-	// Make Generate AI fix / Apply fix buttons match the outlined Create-ignore
-	// style (transparent background, link-coloured border + text, fill on hover).
-	private String injectButtonOverride(String html, String linkColor, String onLinkColor) {
-		String override = "<style id=\"snyk-eclipse-button-override\">"
-				+ "button.generate-ai-fix,button.sn-apply-fix{"
-				+ "background-color:transparent;"
-				+ "color:" + linkColor + ";"
-				+ "border:1px solid " + linkColor + ";"
-				+ "transition:background-color .15s ease-in,color .15s ease-in;"
-				+ "}"
-				+ "button.generate-ai-fix:hover:not(:disabled),"
-				+ "button.sn-apply-fix:hover:not(:disabled){"
-				+ "background-color:" + linkColor + ";"
-				+ "color:" + onLinkColor + ";"
-				+ "}"
-				+ "</style>";
-		int headEnd = html.indexOf("</head>");
-		if (headEnd < 0) {
-			return override + html;
-		}
-		return html.substring(0, headEnd) + override + html.substring(headEnd);
 	}
 
 	private String replaceIgnoreRequestScript(String htmlWithScripts) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
@@ -90,7 +90,9 @@ public class CodeHtmlProvider extends BaseHtmlProvider {
 	// Make Generate AI fix / Apply fix buttons match the outlined Create-ignore
 	// style (transparent background, link-coloured border + text, fill on hover).
 	private String injectButtonOverride(String html, String linkColor, String onLinkColor) {
-		String override = "<style id=\"snyk-eclipse-button-override\">"
+		// CSP in details.html only allows styles with nonce 'ideNonce' or '{{.Nonce}}';
+		// without it the browser silently drops the override.
+		String override = "<style nonce=\"ideNonce\" id=\"snyk-eclipse-button-override\">"
 				+ "button.generate-ai-fix,button.sn-apply-fix{"
 				+ "background-color:transparent;"
 				+ "color:" + linkColor + ";"

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
@@ -68,7 +68,7 @@ public class CodeHtmlProvider extends BaseHtmlProvider {
 		htmlStyled = htmlStyled.replace("var(--example-line-added-color)",
 				super.getColorAsHex("ADDITION_COLOR", "#00ff00"));
 		htmlStyled = htmlStyled.replace("var(--button-background-color)",
-				super.getColorAsHex("BUTTON_COLOR", "#375578"));
+				super.getColorAsHex("org.eclipse.ui.editors.hyperlinkColor", "#4C8DEF"));
 		htmlStyled = htmlStyled.replace("var(--button-text-color)",
 				super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR", "#F5F5F5"));
 		htmlStyled = htmlStyled.replace("var(--disabled-background-color)",

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java
@@ -62,26 +62,52 @@ public class CodeHtmlProvider extends BaseHtmlProvider {
 	public String replaceCssVariables(String html) {
 		String htmlStyled = super.replaceCssVariables(html);
 
+		String linkColor = super.getColorAsHex("org.eclipse.ui.editors.hyperlinkColor", "#4C8DEF");
+		String onLinkColor = super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR", "#FFFFFF");
+
 		// Replace CSS variables with actual color values
 		htmlStyled = htmlStyled.replace("var(--example-line-removed-color)",
 				super.getColorAsHex("DELETION_COLOR", "#ff0000"));
 		htmlStyled = htmlStyled.replace("var(--example-line-added-color)",
 				super.getColorAsHex("ADDITION_COLOR", "#00ff00"));
-		htmlStyled = htmlStyled.replace("var(--button-background-color)",
-				super.getColorAsHex("org.eclipse.ui.editors.hyperlinkColor", "#4C8DEF"));
-		htmlStyled = htmlStyled.replace("var(--button-text-color)",
-				super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR", "#F5F5F5"));
+		htmlStyled = htmlStyled.replace("var(--button-background-color)", linkColor);
+		htmlStyled = htmlStyled.replace("var(--button-text-color)", onLinkColor);
 		htmlStyled = htmlStyled.replace("var(--disabled-background-color)",
 				super.getColorAsHex("org.eclipse.ui.workbench.ACTIVE_TAB_OUTER_KEYLINE_COLOR", "#CCCCCC"));
-		htmlStyled = htmlStyled.replace("var(--vscode-input-border)", super.getColorAsHex("BUTTON_COLOR", "#375578"));
+		htmlStyled = htmlStyled.replace("var(--vscode-input-border)", linkColor);
 		htmlStyled = htmlStyled.replace("var(--warning-text)", super.getColorAsHex("WARNING_TEXT_COLOR", "#000000"));
 		htmlStyled = htmlStyled.replace("var(--warning-background)",
 				super.getColorAsHex("WARNING_BACKGROUND_COLOR", "#c8a000"));
+
+		htmlStyled = injectButtonOverride(htmlStyled, linkColor, onLinkColor);
 
 		String htmlWithScripts = replaceAIFixScripts(htmlStyled);
 		String htmlWithIgnoreRequest = replaceIgnoreRequestScript(htmlWithScripts);
 
 		return htmlWithIgnoreRequest;
+	}
+
+	// Make Generate AI fix / Apply fix buttons match the outlined Create-ignore
+	// style (transparent background, link-coloured border + text, fill on hover).
+	private String injectButtonOverride(String html, String linkColor, String onLinkColor) {
+		String override = "<style id=\"snyk-eclipse-button-override\">"
+				+ "button.generate-ai-fix,button.sn-apply-fix{"
+				+ "background-color:transparent;"
+				+ "color:" + linkColor + ";"
+				+ "border:1px solid " + linkColor + ";"
+				+ "transition:background-color .15s ease-in,color .15s ease-in;"
+				+ "}"
+				+ "button.generate-ai-fix:hover:not(:disabled),"
+				+ "button.sn-apply-fix:hover:not(:disabled){"
+				+ "background-color:" + linkColor + ";"
+				+ "color:" + onLinkColor + ";"
+				+ "}"
+				+ "</style>";
+		int headEnd = html.indexOf("</head>");
+		if (headEnd < 0) {
+			return override + html;
+		}
+		return html.substring(0, headEnd) + override + html.substring(headEnd);
 	}
 
 	private String replaceIgnoreRequestScript(String htmlWithScripts) {


### PR DESCRIPTION
### **User description**
## Summary
- `CodeHtmlProvider` now maps `--button-background-color` to the Eclipse hyperlink color (`org.eclipse.ui.editors.hyperlinkColor`) instead of `BUTTON_COLOR`.

## Why
`BUTTON_COLOR` resolves to a near-background gray in light themes, so the **Generate AI Fix** button blends into the surrounding panel and looks disabled. The hyperlink color key is already used elsewhere in `BaseHtmlProvider` and resolves to a visible blue in both light and dark Eclipse themes.

## Test plan
- [ ] Manual: open issue details for a Code finding in a light theme; the Generate AI Fix button should now be visible against the panel background.
- [ ] Manual: same in a dark theme — button still visible.

Jira: [IDE-1252](https://snyksec.atlassian.net/browse/IDE-1252)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-1252]: https://snyksec.atlassian.net/browse/IDE-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes AI Fix button visibility in light themes.

- Aligns AI Fix/Apply Fix buttons with 'Create Ignore' style.

- Ensures injected styles are applied via CSP nonce.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeHtmlProvider.java</strong><dd><code>Adjusts AI Fix button styling and CSS overrides.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugin/src/main/java/io/snyk/eclipse/plugin/html/CodeHtmlProvider.java

<ul><li>Replaces <code>--button-background-color</code> and <code>--vscode-input-border</code> CSS <br>variables with the hyperlink color for better visibility in light <br>themes.<br> <li> Introduces <code>injectButtonOverride</code> method to apply outlined styling to AI <br>Fix and Apply Fix buttons, making them consistent with the "Create <br>Ignore" button.<br> <li> Adds <code>nonce="ideNonce"</code> to the injected <code><style></code> tag to ensure it is processed <br>by the browser, respecting Content-Security-Policy.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-eclipse-plugin/pull/409/changes#diff-4948302d11cf15d55d6c1cfd60ce8d3d1b9bababf4769a24e6d7ab2a3b9514d8">+33/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

