### PR TITLE
fix: surface CLI download failure to user [IDE-2109]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -103,6 +103,7 @@ public class SnykStartup implements IStartup {
 				String message = "Failed to download Snyk CLI: " + errorMessage
 						+ ". Will try to start with existing binary if available.";
 				logger.error(message);
+				SnykLogger.logAndShow("Snyk CLI download failed: " + errorMessage);
 			}
 		};
 		initJob.setPriority(Job.LONG);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -103,7 +103,8 @@ public class SnykStartup implements IStartup {
 				String message = "Failed to download Snyk CLI: " + errorMessage
 						+ ". Will try to start with existing binary if available.";
 				logger.error(message);
-				SnykLogger.logAndShow("Snyk CLI download failed: " + errorMessage);
+				SnykLogger.logAndShowWarning("Snyk CLI download failed: " + errorMessage
+						+ ". Will try to start with existing binary if available.");
 			}
 		};
 		initJob.setPriority(Job.LONG);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykLogger.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykLogger.java
@@ -27,4 +27,10 @@ public class SnykLogger {
 		StatusManager.getManager().handle(status, StatusManager.LOG | StatusManager.SHOW);
 	}
 
+	public static void logAndShowWarning(String message) {
+		Status status = new Status(IStatus.WARNING, Activator.PLUGIN_ID, message);
+
+		StatusManager.getManager().handle(status, StatusManager.LOG | StatusManager.SHOW);
+	}
+
 }

--- a/tests/src/test/java/io/snyk/eclipse/plugin/utils/SnykLoggerTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/utils/SnykLoggerTest.java
@@ -1,0 +1,34 @@
+package io.snyk.eclipse.plugin.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.ui.statushandlers.StatusManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SnykLoggerTest {
+
+    @Test
+    void logAndShowWarning_usesSeverityWarning() {
+        try (var mockedStatusManager = mockStatic(StatusManager.class)) {
+            var managerMock = org.mockito.Mockito.mock(StatusManager.class);
+            mockedStatusManager.when(StatusManager::getManager).thenReturn(managerMock);
+
+            SnykLogger.logAndShowWarning("CLI download failed: connection timed out. Will try to start with existing binary if available.");
+
+            var captor = ArgumentCaptor.forClass(IStatus.class);
+            org.mockito.Mockito.verify(managerMock, times(1))
+                    .handle(captor.capture(), eq(StatusManager.LOG | StatusManager.SHOW));
+
+            IStatus captured = captor.getValue();
+            assertEquals(IStatus.WARNING, captured.getSeverity(),
+                    "logAndShowWarning must produce WARNING severity so the user notification is not styled as INFO");
+            assertEquals("CLI download failed: connection timed out. Will try to start with existing binary if available.",
+                    captured.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary
- `SnykStartup.logDownloadFailure` now calls `SnykLogger.logAndShow` in addition to the existing error-log write, so CLI download failures surface in Eclipse's status notification area.

## Why
The previous code only wrote to the Eclipse error log, which most users don't open. The CLI then fails later with a confusing message. Users now see a clear "Snyk CLI download failed: <cause>" the moment the download fails — the same surface used by `SnykLanguageServer` for related CLI errors.


Now the path is shown to the user, and they can resolve.
<img width="790" height="468" alt="image" src="https://github.com/user-attachments/assets/4fbc40f4-04aa-496c-adf8-ebaccddeaf29" />


## Test plan
- [ ] Manual: block `static.snyk.io` (or otherwise force the CLI download to 404), restart Eclipse with the Snyk plugin — a status notification with "Snyk CLI download failed: …" appears.

Jira: [IDE-2109](https://snyksec.atlassian.net/browse/IDE-2109)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-2109]: https://snyksec.atlassian.net/browse/IDE-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Surface Snyk CLI download failures.

- Show errors in Eclipse notifications.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI_Download_Failure --> Log_Failure_To_User
  Log_Failure_To_User --> User_Notification["Eclipse Status Notification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SnykStartup.java</strong><dd><code>Display CLI download failures in user notifications.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java

<ul><li>Added a call to <code>SnykLogger.logAndShow()</code> within the <code>logDownloadFailure</code> <br>method.<br> <li> This change makes CLI download failures visible to users in the <br>Eclipse status notification area.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-eclipse-plugin/pull/410/changes#diff-1b1bb08d42c80d5e2acd1f351342e890131504215bc5b16275419c1f063cd03c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

