### PR TITLE
fix: skip auth flow when already authenticated [IDE-1222]

### DIFF
--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -239,6 +239,9 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	}
 
 	public CompletableFuture<Object> triggerAuthentication() {
+		if (Preferences.getInstance().isAuthenticated()) {
+			return CompletableFuture.completedFuture(null);
+		}
 		return executeCommand(LsConstants.COMMAND_LOGIN, new ArrayList<>());
 	}
 


### PR DESCRIPTION
triggerAuthentication unconditionally invoked the snyk.login command, so the post-wizard flow asked users to re-authenticate even when a valid token was already stored. Short-circuit when Preferences reports an authenticated state.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
