### PR TITLE
fix(tree-view): open file nodes in Eclipse editor instead of system default [IDE-2121]

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Version: 3.9.0.qualifier
 Bundle-Activator: io.snyk.eclipse.plugin.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
+ org.eclipse.ui.ide,
  org.eclipse.core.runtime,
+ org.eclipse.core.filesystem,
  org.eclipse.jdt.core,
  org.eclipse.core.resources,
  org.eclipse.lsp4e;bundle-version="0.18.4",

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -67,6 +67,11 @@
             <version>1.17.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.4</version>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -589,17 +589,17 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	}
 
 	private IEditorPart openEditorForUri(IWorkbenchPage page, URI uri) throws PartInitException, CoreException {
-		uri = uri.normalize();
-		if (uri.getPath() != null && uri.getPath().contains("..")) {
-			SnykLogger.logInfo("Rejected URI with path traversal: " + uri);
+		URI normalizedUri = uri.normalize();
+		if (normalizedUri.getPath() != null && normalizedUri.getPath().contains("..")) {
+			SnykLogger.logInfo("Rejected URI with path traversal: " + normalizedUri);
 			return null;
 		}
-		String editorId = resolveInternalEditorId(uri);
-		IFile workspaceFile = LSPEclipseUtils.getFileHandle(uri.toString());
+		String editorId = resolveInternalEditorId(normalizedUri);
+		IFile workspaceFile = LSPEclipseUtils.getFileHandle(normalizedUri.toString());
 		if (workspaceFile != null && workspaceFile.exists()) {
 			return page.openEditor(new org.eclipse.ui.part.FileEditorInput(workspaceFile), editorId);
 		}
-		IFileStore fileStore = EFS.getStore(uri);
+		IFileStore fileStore = EFS.getStore(normalizedUri);
 		return page.openEditor(new FileStoreEditorInput(fileStore), editorId);
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -532,8 +532,12 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			issue = getIssueFromCache(uriDetails.product(), uriDetails.issueId());
 		} else if (FILE_SCHEME.equals(uriDetails.scheme())) {
 			return openFileInEclipse(uri, params.getSelection());
-		} else {
+		} else if ("http".equals(uriDetails.scheme()) || "https".equals(uriDetails.scheme())) {
 			return super.showDocument(params);
+		} else {
+			SnykLogger.logInfo(String.format("Unsupported URI: scheme=%s, product=%s, action=%s, issue=%s",
+					uriDetails.scheme(), uriDetails.product(), uriDetails.action(), uriDetails.issueId()));
+			return CompletableFuture.completedFuture(new ShowDocumentResult(false));
 		}
 
 		if (issue == null) {

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -532,12 +532,8 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			issue = getIssueFromCache(uriDetails.product(), uriDetails.issueId());
 		} else if (FILE_SCHEME.equals(uriDetails.scheme())) {
 			return openFileInEclipse(uri, params.getSelection());
-		} else if ("http".equals(uriDetails.scheme()) || "https".equals(uriDetails.scheme())) {
-			return super.showDocument(params);
 		} else {
-			SnykLogger.logInfo(String.format("Unsupported URI: scheme=%s, product=%s, action=%s, issue=%s",
-					uriDetails.scheme(), uriDetails.product(), uriDetails.action(), uriDetails.issueId()));
-			return CompletableFuture.completedFuture(new ShowDocumentResult(false));
+			return super.showDocument(params);
 		}
 
 		if (issue == null) {

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -46,12 +46,18 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageClientImpl;
 import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ShowDocumentParams;
 import org.eclipse.lsp4j.ShowDocumentResult;
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
@@ -62,9 +68,14 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.FileStoreEditorInput;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -113,6 +124,7 @@ import io.snyk.languageserver.protocolextension.messageObjects.scanResults.Issue
 @SuppressWarnings({"restriction", "PMD.AvoidCatchingGenericException"})
 public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	private static final String MARKER_TYPE = "io.snyk.languageserver.marker";
+	private static final String FILE_SCHEME = "file";
 
 	private ProgressManager progressManager = new ProgressManager(this);
 	private final ObjectMapper om = new ObjectMapper();
@@ -516,10 +528,12 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		Issue issue;
 		if (uriDetails.isValid()) {
 			issue = getIssueFromCache(uriDetails.product(), uriDetails.issueId());
+		} else if (FILE_SCHEME.equals(uriDetails.scheme())) {
+			return openFileInEclipse(uri, params.getSelection());
 		} else {
-			SnykLogger.logInfo(String.format("Invalid URI: scheme=%s, product=%s, action=%s, issue=%s",
+			SnykLogger.logInfo(String.format("Unsupported URI: scheme=%s, product=%s, action=%s, issue=%s",
 					uriDetails.scheme(), uriDetails.product(), uriDetails.action(), uriDetails.issueId()));
-			return super.showDocument(params);
+			return CompletableFuture.completedFuture(new ShowDocumentResult(false));
 		}
 
 		if (issue == null) {
@@ -538,6 +552,72 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			view.selectTreeNode(issue, displayProduct);
 			return new ShowDocumentResult(true);
 		});
+	}
+
+	// Opens a file:// URI inside Eclipse, forcing the default text editor for
+	// unknown file types to avoid routing through macOS LaunchServices (e.g. Windsurf).
+	private CompletableFuture<ShowDocumentResult> openFileInEclipse(URI uri, Range range) {
+		if (Preferences.getInstance().isTest()) {
+			return CompletableFuture.completedFuture(new ShowDocumentResult(false));
+		}
+		return CompletableFuture.supplyAsync(() -> {
+			boolean[] success = { false };
+			Display.getDefault().syncExec(() -> {
+				try {
+					IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+					if (page == null) {
+						return;
+					}
+					IEditorPart editor = openEditorForUri(page, uri);
+					if (editor == null) {
+						return;
+					}
+					if (range != null && editor instanceof ITextEditor) {
+						revealRange((ITextEditor) editor, range);
+					}
+					success[0] = true;
+				} catch (Exception e) {
+					SnykLogger.logError(e);
+				}
+			});
+			return new ShowDocumentResult(success[0]);
+		});
+	}
+
+	private IEditorPart openEditorForUri(IWorkbenchPage page, URI uri) throws PartInitException, CoreException {
+		String editorId = resolveInternalEditorId(uri);
+		IFile workspaceFile = LSPEclipseUtils.getFileHandle(uri.toString());
+		if (workspaceFile != null && workspaceFile.exists()) {
+			return page.openEditor(new org.eclipse.ui.part.FileEditorInput(workspaceFile), editorId);
+		}
+		IFileStore fileStore = EFS.getStore(uri);
+		return page.openEditor(new FileStoreEditorInput(fileStore), editorId);
+	}
+
+	private String resolveInternalEditorId(URI uri) {
+		try {
+			IEditorDescriptor descriptor = IDE.getEditorDescriptor(uri.getPath(), true, false);
+			if (descriptor != null && !descriptor.isOpenExternal()) {
+				return descriptor.getId();
+			}
+		} catch (PartInitException e) {
+			SnykLogger.logError(e);
+		}
+		return "org.eclipse.ui.DefaultTextEditor";
+	}
+
+	private void revealRange(ITextEditor textEditor, Range range) {
+		IDocument doc = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
+		if (doc == null) {
+			return;
+		}
+		try {
+			int startOffset = doc.getLineOffset(range.getStart().getLine()) + range.getStart().getCharacter();
+			int endOffset = doc.getLineOffset(range.getEnd().getLine()) + range.getEnd().getCharacter();
+			textEditor.selectAndReveal(startOffset, endOffset - startOffset);
+		} catch (BadLocationException e) {
+			SnykLogger.logError(e);
+		}
 	}
 
 	private Issue getIssueFromCache(String product, String issueId) {

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -71,10 +71,12 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -531,9 +533,7 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 		} else if (FILE_SCHEME.equals(uriDetails.scheme())) {
 			return openFileInEclipse(uri, params.getSelection());
 		} else {
-			SnykLogger.logInfo(String.format("Unsupported URI: scheme=%s, product=%s, action=%s, issue=%s",
-					uriDetails.scheme(), uriDetails.product(), uriDetails.action(), uriDetails.issueId()));
-			return CompletableFuture.completedFuture(new ShowDocumentResult(false));
+			return super.showDocument(params);
 		}
 
 		if (issue == null) {
@@ -564,7 +564,11 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			boolean[] success = { false };
 			Display.getDefault().syncExec(() -> {
 				try {
-					IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+					if (window == null) {
+						return;
+					}
+					IWorkbenchPage page = window.getActivePage();
 					if (page == null) {
 						return;
 					}
@@ -585,6 +589,11 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	}
 
 	private IEditorPart openEditorForUri(IWorkbenchPage page, URI uri) throws PartInitException, CoreException {
+		uri = uri.normalize();
+		if (uri.getPath() != null && uri.getPath().contains("..")) {
+			SnykLogger.logInfo("Rejected URI with path traversal: " + uri);
+			return null;
+		}
 		String editorId = resolveInternalEditorId(uri);
 		IFile workspaceFile = LSPEclipseUtils.getFileHandle(uri.toString());
 		if (workspaceFile != null && workspaceFile.exists()) {
@@ -607,7 +616,11 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 	}
 
 	private void revealRange(ITextEditor textEditor, Range range) {
-		IDocument doc = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
+		IDocumentProvider provider = textEditor.getDocumentProvider();
+		if (provider == null) {
+			return;
+		}
+		IDocument doc = provider.getDocument(textEditor.getEditorInput());
 		if (doc == null) {
 			return;
 		}

--- a/plugin/src/main/resources/ui/html/settings-fallback.html
+++ b/plugin/src/main/resources/ui/html/settings-fallback.html
@@ -355,6 +355,8 @@
 </form>
 
 <script>
+  // Mirrors the save-on-close logic in infrastructure/configuration/template/js/features/auto-save.js.
+  // Keep both in sync when changing the visibilitychange handler or re-entrance guard.
   (function() {
     if (typeof window.__IS_IDE_AUTOSAVE_ENABLED__ === 'undefined') {
       window.__IS_IDE_AUTOSAVE_ENABLED__ = false;
@@ -362,6 +364,8 @@
 
     var FIELDS = ['cli_path', 'automatic_download', 'binary_base_url', 'cli_release_channel', 'proxy_insecure'];
     var initialState = null;
+    // Guard against re-entrance when blur() triggers getAndSaveIdeConfig
+    var _isSaving = false;
 
     function get(id) {
       return document.getElementById(id);
@@ -461,21 +465,40 @@
     }
 
     window.getAndSaveIdeConfig = function() {
-      if (!validateCliVersion()) {
-        if (typeof window.__ideSaveAttemptFinished__ === 'function') {
-          window.__ideSaveAttemptFinished__('validation_error');
-        }
-        return;
-      }
-      var data = collectChangedData();
+      if (_isSaving) return;
+      _isSaving = true;
+
       try {
-        if (typeof window.__saveIdeConfig__ === 'function') {
-          window.__saveIdeConfig__(JSON.stringify(data));
-          captureInitialState();
-          notifyDirty(false);
+        // Commit any focused text input or select value before collecting.
+        // Closing the panel without blurring silently discards uncommitted changes
+        // because blur never fires. The _isSaving guard prevents recursion.
+        var active = document.activeElement;
+        if (active && typeof active.blur === 'function' &&
+            (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.tagName === 'SELECT') &&
+            active.type !== 'checkbox' && active.type !== 'radio' && active.type !== 'button' && active.type !== 'hidden' &&
+            !active.readOnly && !active.disabled) {
+          active.blur();
         }
-      } catch (e) {
-        console.error('Error saving configuration:', e);
+
+        if (!validateCliVersion()) {
+          if (typeof window.__ideSaveAttemptFinished__ === 'function') {
+            window.__ideSaveAttemptFinished__('validation_error');
+          }
+          return;
+        }
+
+        var data = collectChangedData();
+        try {
+          if (typeof window.__saveIdeConfig__ === 'function') {
+            window.__saveIdeConfig__(JSON.stringify(data));
+            captureInitialState();
+            notifyDirty(false);
+          }
+        } catch (e) {
+          console.error('Error saving configuration:', e);
+        }
+      } finally {
+        _isSaving = false;
       }
     };
 
@@ -553,6 +576,16 @@
       toggleCustomVersionInput();
       validateCliVersion();
       captureInitialState();
+
+      // Save when the panel becomes hidden (e.g. closed in VS Code) without a prior blur.
+      // Closing a webview does not fire blur on the focused element, so text field changes
+      // typed but not yet blurred would otherwise be silently discarded.
+      // Only fires for auto-save IDEs; non-auto-save IDEs use an explicit OK/Cancel flow.
+      document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'hidden' && window.__IS_IDE_AUTOSAVE_ENABLED__) {
+          window.getAndSaveIdeConfig();
+        }
+      });
     });
   })();
 </script>

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -10,6 +10,7 @@ import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_PARAMS_OSS;
 import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_PARAMS_TO_DISPLAYED;
 import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_STATE_IN_PROGRESS;
 import static io.snyk.eclipse.plugin.domain.ProductConstants.SCAN_STATE_SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -996,15 +997,16 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 	}
 
 	@Test
-	void showDocument_withUnsupportedScheme_returnsFalse() throws Exception {
+	void showDocument_withUnsupportedScheme_delegatesToSuper() {
 		cut = new SnykExtendedLanguageClient();
 
 		ShowDocumentParams params = new ShowDocumentParams();
 		params.setUri("vscode://extension/something");
 
-		ShowDocumentResult result = cut.showDocument(params).get(5, TimeUnit.SECONDS);
-
-		assertFalse(result.isSuccess());
+		// Unknown schemes are delegated to the LSP4E super implementation.
+		// Verify a future is returned (delegation happened); don't assert the result
+		// since super runs async UI operations unavailable in headless tests.
+		assertDoesNotThrow(() -> cut.showDocument(params));
 	}
 
 	@Test

--- a/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClientTest.java
@@ -963,6 +963,62 @@ class SnykExtendedLanguageClientTest extends LsBaseTest {
 		}
 	}
 
+	// file:// URIs must be handled by our own openFileInEclipse, not super.showDocument.
+	// In test mode, openFileInEclipse returns false (isTest() guard) without delegating to
+	// LSP4E's default which can route to the OS (Windsurf) for unknown file extensions.
+	@Test
+	void showDocument_withFileUri_returnsFalseInTestMode() throws Exception {
+		cut = new SnykExtendedLanguageClient();
+
+		ShowDocumentParams params = new ShowDocumentParams();
+		params.setUri("file:///some/path/secret.key");
+
+		ShowDocumentResult result = cut.showDocument(params).get(5, TimeUnit.SECONDS);
+
+		// test mode: isTest() guard skips actual editor open, returns false without OS delegation
+		assertFalse(result.isSuccess());
+	}
+
+	@Test
+	void showDocument_withFileUriAndRange_returnsFalseInTestMode() throws Exception {
+		cut = new SnykExtendedLanguageClient();
+
+		ShowDocumentParams params = new ShowDocumentParams();
+		params.setUri("file:///some/path/config.md");
+		org.eclipse.lsp4j.Range range = new org.eclipse.lsp4j.Range(
+				new org.eclipse.lsp4j.Position(2, 0),
+				new org.eclipse.lsp4j.Position(2, 10));
+		params.setSelection(range);
+
+		ShowDocumentResult result = cut.showDocument(params).get(5, TimeUnit.SECONDS);
+
+		assertFalse(result.isSuccess());
+	}
+
+	@Test
+	void showDocument_withUnsupportedScheme_returnsFalse() throws Exception {
+		cut = new SnykExtendedLanguageClient();
+
+		ShowDocumentParams params = new ShowDocumentParams();
+		params.setUri("vscode://extension/something");
+
+		ShowDocumentResult result = cut.showDocument(params).get(5, TimeUnit.SECONDS);
+
+		assertFalse(result.isSuccess());
+	}
+
+	@Test
+	void showDocument_withUnsupportedSnykAction_returnsFalse() throws Exception {
+		cut = new SnykExtendedLanguageClient();
+
+		ShowDocumentParams params = new ShowDocumentParams();
+		params.setUri("snyk:///test?product=code&action=unknownAction&issueId=abc");
+
+		ShowDocumentResult result = cut.showDocument(params).get(5, TimeUnit.SECONDS);
+
+		assertFalse(result.isSuccess());
+	}
+
 	// Fix 2: normalizeProductCodename must map SCAN_PARAMS_* constants to DIAGNOSTIC_SOURCE_* constants
 	@Test
 	void normalizeProductCodename_oss_returnsDiagnosticSourceSnykOss() {


### PR DESCRIPTION
### Description

Clicking a node in the HTML tree view (Secrets product) for files with no registered Eclipse editor (`.key`, `.md`, etc.) was opening the file in Windsurf (or whatever app macOS had set as default) instead of Eclipse.

Root cause: `showDocument` fell through to LSP4E's default handler which calls `IDE.openEditorOnFileStore` without an explicit editor ID — Eclipse's registry then returns "System Editor" for unknown types, delegating to macOS LaunchServices.

Fix: intercept `file://` URIs before they reach `super.showDocument()`, resolve the editor ID via `IDE.getEditorDescriptor` with external editors disallowed, and fall back to `"org.eclipse.ui.DefaultTextEditor"` — preventing any OS delegation.

Jira: https://snyksec.atlassian.net/browse/IDE-2121

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Before: clicking a `.key` secret node → Windsurf opens._
_After: clicking a `.key` secret node → Eclipse default text editor opens with selection on the issue range._