### PR TITLE
fix(tree-view): show issue details panel when clicking HTML tree nodes [IDE-2124]

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -555,8 +555,11 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 			if (productNode != null) {
 				IssueTreeNode issueNode = findIssueTreeNode((TreeNode) productNode, issue.id());
 				if (issueNode != null) {
-					selectedNode = issueNode;
-					Display.getDefault().asyncExec(() -> browserHandler.updateBrowserContent(issueNode));
+					final IssueTreeNode finalNode = issueNode;
+					runOnDisplay(() -> {
+						selectedNode = finalNode;
+						browserHandler.updateBrowserContent(finalNode);
+					});
 				}
 			}
 			return;
@@ -580,18 +583,12 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	}
 
 	private void selectTreenodeForIssue(TreeNode currentParent, Issue issue) {
-		for (Object child : currentParent.getChildren()) {
-			TreeNode childNode = (TreeNode) child;
+		IssueTreeNode node = findIssueTreeNode(currentParent, issue.id());
+		if (node != null) updateSelection(node);
+	}
 
-			if (childNode instanceof IssueTreeNode && ((IssueTreeNode) childNode).getIssue().id().equals(issue.id())) {
-				updateSelection((IssueTreeNode) childNode);
-				return; // Exit the function as we've found a match
-			}
-
-			if (childNode.getChildren() != null && childNode.getChildren().length != 0) {
-				selectTreenodeForIssue(childNode, issue);
-			}
-		}
+	protected void runOnDisplay(Runnable runnable) {
+		Display.getDefault().asyncExec(runnable);
 	}
 
 	private void updateSelection(IssueTreeNode issueTreeNode) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -548,12 +548,15 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 			if (treeBrowserHandler != null) {
 				Display.getDefault().asyncExec(() -> treeBrowserHandler.selectNode(issue.id()));
 			}
-			// selectTreenodeForIssue triggers selectionChanged on the hidden SWT tree,
-			// which updates the detail browser panel via browserHandler.updateBrowserContent.
-			if (treeViewer != null) {
-				ProductTreeNode productNode = getProductNode(product, issue.filePath());
-				if (productNode != null) {
-					selectTreenodeForIssue((TreeNode) productNode, issue);
+			// treeViewer.setSelection on a hidden StackLayout control does not fire
+			// ISelectionChangedListener, so drive the detail panel update directly.
+			if (treeViewer == null) return;
+			ProductTreeNode productNode = getProductNode(product, issue.filePath());
+			if (productNode != null) {
+				IssueTreeNode issueNode = findIssueTreeNode((TreeNode) productNode, issue.id());
+				if (issueNode != null) {
+					selectedNode = issueNode;
+					Display.getDefault().asyncExec(() -> browserHandler.updateBrowserContent(issueNode));
 				}
 			}
 			return;
@@ -561,6 +564,19 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		ProductTreeNode productNode = getProductNode(product, issue.filePath());
 		if (productNode == null) return;
 		selectTreenodeForIssue((TreeNode) productNode, issue);
+	}
+
+	private IssueTreeNode findIssueTreeNode(TreeNode parent, String issueId) {
+		if (parent == null || parent.getChildren() == null) return null;
+		for (Object child : parent.getChildren()) {
+			TreeNode node = (TreeNode) child;
+			if (node instanceof IssueTreeNode && ((IssueTreeNode) node).getIssue().id().equals(issueId)) {
+				return (IssueTreeNode) node;
+			}
+			IssueTreeNode found = findIssueTreeNode(node, issueId);
+			if (found != null) return found;
+		}
+		return null;
 	}
 
 	private void selectTreenodeForIssue(TreeNode currentParent, Issue issue) {

--- a/tests/src/test/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolViewTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolViewTest.java
@@ -2,10 +2,14 @@ package io.snyk.eclipse.plugin.views.snyktoolview;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.jface.viewers.TreeViewer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -91,6 +95,55 @@ class SnykToolViewTest {
 				.store(Preferences.USE_HTML_TREE_VIEW, "true");
 		SnykToolView view = new SnykToolView();
 		assertDoesNotThrow(() -> view.selectTreeNode(null, "Snyk Code"));
+	}
+
+	@Test
+	void selectTreeNode_withHtmlTreeViewEnabled_updatesContentPanel() throws Exception {
+		Preferences.getTestInstance(new InMemoryPreferenceStore(), new InMemorySecurePreferenceStore())
+				.store(Preferences.USE_HTML_TREE_VIEW, "true");
+
+		Issue issue = new Issue("issue-id", "Test Issue", "high", "/some/path/File.java",
+				null, false, false, "Code Security", null, null);
+
+		// Build a product-like tree node without going through ProductTreeNode's
+		// constructor (which calls SnykIcons and Activator — unavailable headlessly).
+		// findIssueTreeNode accepts TreeNode, and the cast in selectTreeNode is
+		// (TreeNode) productNode, so a BaseTreeNode subclass suffices.
+		IssueTreeNode issueNode = new IssueTreeNode(issue);
+		ProductTreeNode mockProductNode = mock(ProductTreeNode.class);
+		when(mockProductNode.getChildren()).thenReturn(new IssueTreeNode[] { issueNode });
+
+		BrowserHandler mockBrowserHandler = mock(BrowserHandler.class);
+		TreeViewer mockTreeViewer = mock(TreeViewer.class);
+
+		// Subclass overrides:
+		// - getProductNode: returns our mock tree with the IssueTreeNode child
+		// - runOnDisplay: runs the runnable synchronously so verify() sees the call
+		SnykToolView view = new SnykToolView() {
+			@Override
+			public ProductTreeNode getProductNode(String product, String folderPath) {
+				return mockProductNode;
+			}
+
+			@Override
+			protected void runOnDisplay(Runnable runnable) {
+				runnable.run();
+			}
+		};
+
+		// Inject mock browserHandler via reflection.
+		Field browserHandlerField = SnykToolView.class.getDeclaredField("browserHandler");
+		browserHandlerField.setAccessible(true);
+		browserHandlerField.set(view, mockBrowserHandler);
+
+		// Inject mock treeViewer so the treeViewer == null guard does not short-circuit.
+		Field treeViewerField = SnykToolView.class.getDeclaredField("treeViewer");
+		treeViewerField.setAccessible(true);
+		treeViewerField.set(view, mockTreeViewer);
+
+		view.selectTreeNode(issue, "Snyk Code");
+
+		verify(mockBrowserHandler).updateBrowserContent(issueNode);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description

Fixes [IDE-2124](https://snyksec.atlassian.net/browse/IDE-2124).

When `USE_HTML_TREE_VIEW` is enabled (default since IDE-1837), clicking an issue node in the HTML tree showed the default "Select an issue and start improving your project." placeholder instead of issue details.

**Root cause:** `selectTreeNode()` called `treeViewer.setSelection()` on the hidden `StackLayout` control — `TreeViewer` is behind the HTML tree `Browser`. SWT does not fire `ISelectionChangedListener` for `setSelection()` on a non-visible control, so `browserHandler.updateBrowserContent()` was never reached.

**Fix:** When HTML tree mode is active, find the `IssueTreeNode` directly and call `browserHandler.updateBrowserContent()` without routing through the hidden SWT tree's selection listener.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Before: details panel shows placeholder on HTML tree node click. After: issue details render correctly._

[IDE-2124]: https://snyksec.atlassian.net/browse/IDE-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ