### PR TITLE
fix(IDE-2112): show clean incompatible-CLI dialog, suppress Problem Occurred and wizard

### DIFF
--- a/.cursor/skills/ide-pr-testing-strategy/SKILL.md
+++ b/.cursor/skills/ide-pr-testing-strategy/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: ide-pr-testing-strategy
+description: >-
+  Reviews IDE plugin PRs against the Team IDE Testing Strategy (LDX-Sync / config
+  sync) and suggests automated tests, CI gates, and manual QA. Use when reviewing
+  a pull request, asking for test coverage improvements, QA plan for IDE-1652, or
+  mapping changes to the Confluence Testing Strategy page.
+---
+
+# IDE PR Testing Strategy Review
+
+Apply the [IDE Testing Strategy](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4612227128/Testing+Strategy) to a PR under review. Output **actionable test and QA suggestions** the author can land in the same PR (or the next stack PR).
+
+**Not a substitute for** `review-tests` (test quality) or `pr-review-bot` (logic/security). Use this skill when the question is: *does this PR satisfy our release testing strategy, and what should we add?*
+
+## Inputs
+
+Resolve in order:
+
+1. **PR scope** — URL, branch name, or `gh pr diff`. If user gives a stack position (e.g. "2/3 wiring"), use [reference.md](reference.md) stack table.
+2. **Strategy source** — prefer, in order:
+   - Confluence: page `4612227128` in space IDE (`getConfluencePage` with cloudId for `snyksec.atlassian.net`)
+   - Repo doc: `docs/IDE-1652-testing-qa-plan.md` (Eclipse IDE-1652)
+   - This skill: [reference.md](reference.md)
+3. **Changed files** — `git diff` base...HEAD or PR files list.
+
+## Workflow
+
+Copy and track:
+
+```
+Progress:
+- [ ] Step 1: Classify PR (repo, layer, stack role)
+- [ ] Step 2: Map diff → strategy sections (§1–§8)
+- [ ] Step 3: Inventory existing tests touched / missing
+- [ ] Step 4: Cross-IDE parity check (VS Code / IntelliJ patterns)
+- [ ] Step 5: Emit recommendations (automated / CI / manual)
+```
+
+### Step 1: Classify the PR
+
+| Signal | Classification |
+|--------|----------------|
+| `LsSettingsRegistry`, protocol POJOs only | **Foundation** (Eclipse #394-like) |
+| `$/snyk.configuration`, `LsConfigurationUpdater`, `FolderConfigSettings` | **Wiring** (#395-like) |
+| `HTMLSettingsPreferencePage`, `settings-fallback.html` | **HTML migration** (#396-like) |
+| Deletions only, native UI / legacy POJOs | **Cleanup** (#393-like) — verify base branch and compile |
+| `snyk-ls` config / LDX | **LS-primary** — link LS tests; IDE adapter only if touched |
+| VS Code / IntelliJ settings webview | **IDE adapter** — integration + unit on persistence |
+
+**Stack rule (IDE-1652):** review order 394 → 395 → 396 → 393. Cleanup PR must target the HTML migration branch, not `main`.
+
+### Step 2: Map diff → strategy sections
+
+For each changed production file, assign primary section(s):
+
+| § | Topic | IDE must prove (automate if possible) |
+|---|--------|--------------------------------------|
+| §1 | Persistence & migration | Upgrade keeps prefs; folder config round-trip; explicit-changed on real diffs |
+| §2 | Context-aware config | Per-folder settings reach LS outbound payload (defer multi-project to LS) |
+| §3 | Locked / origin UI | Wire format for `isLocked` / origin — manual UI until rendered |
+| §4 | Lifecycle | Init options shape; re-auth refetch; offline cache (LS-heavy) |
+| §5 | Scan parity | Save → outbound `LspConfigurationParam` golden JSON |
+| §6 | External MDM | LS tests + manual exploratory |
+| §7 | Errors & injection | Invalid config graceful; token not inbound-persisted; XSS on HTML subs |
+| §8 | Performance | Manual checklist only |
+
+Tag each gap: **LS-Auto** | **IDE-Auto** | **Manual** | **Planned** (see [reference.md](reference.md)).
+
+### Step 3: Inventory tests
+
+Search the repo for tests related to changed types:
+
+- **Eclipse:** `tests/src/test/java/**/*Test.java`, run pattern `./mvnw test -pl plugin,tests`
+- **VS Code:** `src/test/unit/**`, `src/test/integration/**`, `npm run test:unit`
+- **IntelliJ:** `src/test/kotlin/**`, `./gradlew test`
+- **snyk-ls:** `*_test.go`, `INTEG_TESTS=1`, `SMOKE_TESTS=1`
+
+For each strategy row touched by the diff, answer:
+
+- Is there a test that would **fail** if this PR regressed?
+- Does the test assert **values** or only `changed` / non-null?
+- Was a test **deleted** without replacement (red flag for #393-like PRs)?
+
+### Step 4: Cross-IDE parity
+
+If the change touches config save/load or LSP config:
+
+| Eclipse | VS Code | IntelliJ |
+|---------|---------|----------|
+| `HTMLSettingsPreferencePageTest` | `configurationPersistenceService.test.ts` | `SaveConfigHandlerTest` |
+| `SnykExtendedLanguageClientTest` | `configuration.test.ts` (integration) | `SnykProjectSettingsConfigurableTest` |
+| `LsConfigurationUpdaterTest` | `serverSettingsToLspConfigurationParam.test.ts` | folder config tests |
+
+Suggest aligning JSON fixture shapes (snake_case folder keys, skip inbound `token`, explicit-changed semantics).
+
+### Step 5: Recommendations
+
+Prioritize:
+
+- **P0** — merge blocker: missing test for known Critical review pattern (see [reference.md](reference.md) traceability table)
+- **P1** — should add in same PR: closes strategy gap marked "No" on Confluence
+- **P2** — follow-up: CI gate, shared fixtures, Confluence link updates
+- **Manual** — short exploratory bullet for beta sheet only
+
+Each automated suggestion MUST include:
+
+- Suggested **test class and method name** (e.g. `parseAndSaveConfig_folderConfigRoundTrip_preferredOrg`)
+- **Strategy §** and **Confluence scenario** (plain language)
+- **Fixture** hint (inline JSON snippet or `tests/resources/config-fixtures/...`)
+
+## Output format
+
+Use this template for the user (PR comment, review doc, or chat):
+
+```markdown
+# Testing strategy review — [PR title / URL]
+
+## PR classification
+- **Repo:** …
+- **Role:** Foundation | Wiring | HTML | Cleanup | LS | Other
+- **Stack:** … (if applicable)
+
+## Strategy coverage
+
+| § | Scenario (short) | Current coverage | Gap |
+|---|------------------|------------------|-----|
+| §1 | … | LS-Auto / IDE-Auto / None | … |
+
+## Recommended automated tests (add in this PR)
+
+### P0
+1. **`ClassName#methodName`** — …
+   - Fixture: `{ ... }`
+   - Strategy: §… — …
+
+### P1
+…
+
+## CI / repo improvements
+- …
+
+## Manual QA (keep out of CI)
+- [ ] …
+
+## Confluence updates
+Suggest marking row "…" as **IDE-Auto** with link to `ClassName#methodName` after merge.
+
+## Verdict
+**Testing: READY | NEEDS TESTS | NEEDS MANUAL PLAN**
+
+One sentence rationale.
+```
+
+## Eclipse IDE-1652 quick triggers
+
+If the diff includes any of these, cross-check [reference.md](reference.md) **IDE-1652 matrix**:
+
+- `LsSettingsRegistry`, `LspConfigurationParam`, `ConfigSetting`
+- `persistGlobalSettings`, `markExplicitlyChanged`, `EXPLICIT_CHANGES`
+- `HTMLSettingsPreferencePage`, `loadFallbackHtml`, `settings-fallback.html`
+- `FolderConfigSettings`, `processFolderConfig`
+- Deletion of `PreferencesPage`, `IdeConfigData`, factory tests
+
+## Tools
+
+| Tool | Use |
+|------|-----|
+| `gh pr diff`, `gh pr view` | PR files and description |
+| Confluence MCP | Fresh strategy page body |
+| `Grep` / `Glob` | Find tests and peers |
+| `Read` | `docs/IDE-1652-testing-qa-plan.md` in snyk-eclipse-plugin |
+
+## Additional resources
+
+- Strategy sections and IDE-1652 P0 tests: [reference.md](reference.md)
+- Full Eclipse QA plan (shareable doc): `snyk-eclipse-plugin/docs/IDE-1652-testing-qa-plan.md`

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/SnykStartup.java
@@ -55,15 +55,17 @@ public class SnykStartup implements IStartup {
 				monitor.subTask("Starting Language Server...");
 
 				try {
-					SnykLanguageServer.startSnykLanguageServer();
+					boolean started = SnykLanguageServer.startSnykLanguageServer();
 
-					PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
-						Preferences prefs = Preferences.getInstance();
-						if (!prefs.isAuthenticated() && !prefs.isTest()) {
-							monitor.subTask("Starting Snyk Wizard to configure initial settings...");
-							SnykWizard.createAndLaunch();
-						}
-					});
+					if (started) {
+						PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
+							Preferences prefs = Preferences.getInstance();
+							if (!prefs.isAuthenticated() && !prefs.isTest()) {
+								monitor.subTask("Starting Snyk Wizard to configure initial settings...");
+								SnykWizard.createAndLaunch();
+							}
+						});
+					}
 				} catch (RuntimeException e) { // NOPMD - intentional catch-all of runtime exceptions for UI initialization
 					SnykLogger.logError(e);
 				}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykLogger.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/utils/SnykLogger.java
@@ -15,6 +15,12 @@ public class SnykLogger {
 		StatusManager.getManager().handle(status, StatusManager.SHOW | StatusManager.LOG);
 	}
 
+	public static void logDebug(String message) {
+		Status status = new Status(IStatus.INFO, Activator.PLUGIN_ID, message);
+
+		StatusManager.getManager().handle(status, StatusManager.LOG);
+	}
+
 	public static void logInfo(String message) {
 		Status status = new Status(IStatus.INFO, Activator.PLUGIN_ID, message);
 

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -147,14 +147,15 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		Display display = PlatformUI.getWorkbench().getDisplay();
 		display.asyncExec(() -> new MessageDialog(display.getActiveShell(),
 				"Snyk CLI version incompatible", null,
-				"Plugin protocol version: " + expected + ". CLI protocol version: " + actual + ".",
+				"This plugin requires Snyk CLI protocol version " + expected
+						+ ". Your CLI reports protocol version " + actual + ".",
 				MessageDialog.ERROR, new String[] { "OK" }, 0) {
 			@Override
 			protected Control createCustomArea(Composite parent) {
 				Link link = new Link(parent, SWT.NONE);
-				link.setText("See the <a href=\"https://docs.snyk.io/scm-ide-and-ci-cd-integrations"
-						+ "/snyk-ide-plugins-and-extensions/eclipse-plugin\">compatibility matrix</a>"
-						+ " for supported versions.");
+				link.setText("Use the <a href=\"https://docs.snyk.io/scm-ide-and-ci-cd-integrations"
+						+ "/snyk-ide-plugins-and-extensions/eclipse-plugin\">IDE Plugin Compatibility Matrix</a>"
+						+ " to find a compatible CLI version.");
 				link.addListener(SWT.Selection, event -> Program.launch(event.text));
 				return link;
 			}

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -15,6 +15,7 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -45,7 +46,6 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		waitForInit();
 
 		String cliPath = getCliPathOrThrow(prefs);
-		verifyCliProtocolVersion(cliPath);
 
 		List<String> commands = Lists.of(cliPath, "language-server", "-l", "info");
 		String workingDir = SystemUtils.USER_DIR;
@@ -80,9 +80,11 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		} catch (NumberFormatException e) {
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			showIncompatibleCliDialog(expected, -1);
-			SnykLogger.logDebug("verifyCliProtocolVersion: unexpected output: " + output);
+			// Log raw output at debug only — don't pass NFE as cause or lsp4e will
+			// surface "For input string: ..." in the "Problem Occurred" dialog.
+			SnykLogger.logDebug("verifyCliProtocolVersion: unexpected output: " + output + " (" + e.getMessage() + ")");
 			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible with this version of the Eclipse plugin. Please update the Snyk CLI.";
-			throw new IOException(msg, e);
+			throw new IOException(msg);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			SnykLogger.logInfo("CLI protocol version check interrupted.");
@@ -137,6 +139,14 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 	}
 
 	public static void startSnykLanguageServer() {
+		Preferences prefs = Preferences.getInstance();
+		try {
+			String cliPath = getCliPathOrThrow(prefs);
+			verifyCliProtocolVersion(cliPath);
+		} catch (IOException e) {
+			SnykLogger.logInfo("Not starting Snyk Language Server: " + e.getMessage());
+			return;
+		}
 		LanguageServerDefinition definition = LanguageServersRegistry.getInstance()
 				.getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID);
 		LanguageServiceAccessor.startLanguageServer(definition);
@@ -153,6 +163,9 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 			@Override
 			protected Control createCustomArea(Composite parent) {
 				Link link = new Link(parent, SWT.WRAP);
+				GridData gd = new GridData(SWT.FILL, SWT.TOP, true, false);
+				gd.widthHint = 500;
+				link.setLayoutData(gd);
 				link.setText("Your Snyk CLI version is incompatible with this Snyk plugin. "
 						+ "This Snyk plugin requires expected: " + expected + " vs actual: " + actualStr + ". "
 						+ "Upgrade the Snyk CLI or enable automatic updates in Snyk plugin settings. "

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -73,10 +73,9 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 				throw new IOException(msg);
 			}
 		} catch (NumberFormatException e) {
-			String truncated = output.length() > 80 ? output.substring(0, 80) + "..." : output;
+			String truncated = output.length() > 40 ? output.substring(0, 40) + "..." : output;
 			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible: "
-					+ "'snyk language-server --protocolVersion' did not return a version number "
-					+ "(got: '" + truncated + "'). Please update the Snyk CLI.";
+					+ "'--protocolVersion' gave unexpected output (got: '" + truncated + "'). Please update the Snyk CLI.";
 			SnykLogger.logAndShowError(msg);
 			throw new IOException(msg, e);
 		} catch (InterruptedException e) {

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -77,12 +77,12 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 						+ ". Please update the Snyk CLI.";
 				throw new IOException(msg);
 			}
-		} catch (NumberFormatException e) { //NOPMD - PreserveStackTrace: NFE cause intentionally dropped; passing it would surface "For input string: ..." in lsp4e's "Problem Occurred" dialog (IDE-2112)
+		} catch (NumberFormatException e) {
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			showIncompatibleCliDialog(expected, -1);
 			SnykLogger.logDebug("verifyCliProtocolVersion: unexpected output: " + output + " (" + e.getMessage() + ")");
 			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible with this version of the Eclipse plugin. Please update the Snyk CLI.";
-			throw new IOException(msg);
+			throw new IOException(msg); //NOPMD - PreserveStackTrace: NFE cause intentionally dropped to keep raw CLI output out of lsp4e's "Problem Occurred" dialog (IDE-2112)
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			SnykLogger.logInfo("CLI protocol version check interrupted.");

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -168,7 +168,7 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 				gd.widthHint = 500;
 				link.setLayoutData(gd);
 				link.setText("Your Snyk CLI version is incompatible with this Snyk plugin. "
-						+ "This Snyk plugin requires expected: " + expected + " vs actual: " + actualStr + ". "
+						+ "This plugin requires protocol version " + expected + ", but the installed CLI reports version " + actualStr + ". "
 						+ "Upgrade the Snyk CLI or enable automatic updates in Snyk plugin settings. "
 						+ "For a list of compatible CLI versions, visit the "
 						+ "<a href=\"https://docs.snyk.io/developer-tools/snyk-ide-plugins-and-extensions"

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -147,15 +147,17 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		Display display = PlatformUI.getWorkbench().getDisplay();
 		display.asyncExec(() -> new MessageDialog(display.getActiveShell(),
 				"Snyk CLI version incompatible", null,
-				"This plugin requires Snyk CLI protocol version " + expected
-						+ ". Your CLI reports protocol version " + actual + ".",
+				"",
 				MessageDialog.ERROR, new String[] { "OK" }, 0) {
 			@Override
 			protected Control createCustomArea(Composite parent) {
-				Link link = new Link(parent, SWT.NONE);
-				link.setText("Use the <a href=\"https://docs.snyk.io/scm-ide-and-ci-cd-integrations"
-						+ "/snyk-ide-plugins-and-extensions/eclipse-plugin\">IDE Plugin Compatibility Matrix</a>"
-						+ " to find a compatible CLI version.");
+				Link link = new Link(parent, SWT.WRAP);
+				link.setText("Your Snyk CLI version is incompatible with this Snyk plugin. "
+						+ "This Snyk plugin requires expected: " + expected + " vs actual: " + actual + ". "
+						+ "Upgrade the Snyk CLI or enable automatic updates in Snyk plugin settings. "
+						+ "For a list of compatible CLI versions, visit the "
+						+ "<a href=\"https://docs.snyk.io/developer-tools/snyk-ide-plugins-and-extensions"
+						+ "/compatibility-matrix\">IDE Plugin Compatibility Matrix</a>.");
 				link.addListener(SWT.Selection, event -> Program.launch(event.text));
 				return link;
 			}

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -77,11 +77,9 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 						+ ". Please update the Snyk CLI.";
 				throw new IOException(msg);
 			}
-		} catch (NumberFormatException e) {
+		} catch (NumberFormatException e) { //NOPMD - PreserveStackTrace: NFE cause intentionally dropped; passing it would surface "For input string: ..." in lsp4e's "Problem Occurred" dialog (IDE-2112)
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			showIncompatibleCliDialog(expected, -1);
-			// Log raw output at debug only — don't pass NFE as cause or lsp4e will
-			// surface "For input string: ..." in the "Problem Occurred" dialog.
 			SnykLogger.logDebug("verifyCliProtocolVersion: unexpected output: " + output + " (" + e.getMessage() + ")");
 			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible with this version of the Eclipse plugin. Please update the Snyk CLI.";
 			throw new IOException(msg);

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -14,7 +14,12 @@ import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.ui.PlatformUI;
 
 import com.google.gson.Gson;
@@ -67,9 +72,9 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 			int actual = Integer.parseInt(firstLine);
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			if (actual != expected) {
+				showVersionMismatchDialog(expected, actual);
 				String msg = "Snyk CLI protocol version mismatch: expected " + expected + ", got " + actual
 						+ ". Please update the Snyk CLI.";
-				SnykLogger.logAndShowError(msg);
 				throw new IOException(msg);
 			}
 		} catch (NumberFormatException e) {
@@ -135,6 +140,25 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		LanguageServerDefinition definition = LanguageServersRegistry.getInstance()
 				.getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID);
 		LanguageServiceAccessor.startLanguageServer(definition);
+	}
+
+	static void showVersionMismatchDialog(int expected, int actual) {
+		if (!PlatformUI.isWorkbenchRunning()) return;
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		display.asyncExec(() -> new MessageDialog(display.getActiveShell(),
+				"Snyk CLI version incompatible", null,
+				"Plugin protocol version: " + expected + ". CLI protocol version: " + actual + ".",
+				MessageDialog.ERROR, new String[] { "OK" }, 0) {
+			@Override
+			protected Control createCustomArea(Composite parent) {
+				Link link = new Link(parent, SWT.NONE);
+				link.setText("See the <a href=\"https://docs.snyk.io/scm-ide-and-ci-cd-integrations"
+						+ "/snyk-ide-plugins-and-extensions/eclipse-plugin\">compatibility matrix</a>"
+						+ " for supported versions.");
+				link.addListener(SWT.Selection, event -> Program.launch(event.text));
+				return link;
+			}
+		}.open());
 	}
 
 	/**

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -55,22 +55,33 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 	}
 
 	static void verifyCliProtocolVersion(String cliPath) throws IOException {
+		String output = "";
 		try {
 			ProcessBuilder pb = new ProcessBuilder(cliPath, "language-server", "--protocolVersion");
 			pb.redirectErrorStream(true);
 			Process proc = pb.start();
-			String output = new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+			output = new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
 			proc.waitFor(5, TimeUnit.SECONDS);
-			int actual = Integer.parseInt(output);
+			// Use first line only: some CLI builds print version + trailing warnings.
+			String firstLine = output.split("\\n", 2)[0].trim();
+			int actual = Integer.parseInt(firstLine);
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			if (actual != expected) {
 				String msg = "Snyk CLI protocol version mismatch: expected " + expected + ", got " + actual
 						+ ". Please update the Snyk CLI.";
-				SnykLogger.logAndShow(msg);
+				SnykLogger.logAndShowError(msg);
 				throw new IOException(msg);
 			}
-		} catch (NumberFormatException | InterruptedException e) {
-			SnykLogger.logError(e);
+		} catch (NumberFormatException e) {
+			String truncated = output.length() > 80 ? output.substring(0, 80) + "..." : output;
+			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible: "
+					+ "'snyk language-server --protocolVersion' did not return a version number "
+					+ "(got: '" + truncated + "'). Please update the Snyk CLI.";
+			SnykLogger.logAndShowError(msg);
+			throw new IOException(msg);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			SnykLogger.logInfo("CLI protocol version check interrupted.");
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -72,16 +72,17 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 			int actual = Integer.parseInt(firstLine);
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			if (actual != expected) {
-				showVersionMismatchDialog(expected, actual);
+				showIncompatibleCliDialog(expected, actual);
 				String msg = "Snyk CLI protocol version mismatch: expected " + expected + ", got " + actual
 						+ ". Please update the Snyk CLI.";
 				throw new IOException(msg);
 			}
 		} catch (NumberFormatException e) {
+			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
+			showIncompatibleCliDialog(expected, -1);
 			String truncated = output.length() > 40 ? output.substring(0, 40) + "..." : output;
 			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible: "
 					+ "'--protocolVersion' gave unexpected output (got: '" + truncated + "'). Please update the Snyk CLI.";
-			SnykLogger.logAndShowError(msg);
 			throw new IOException(msg, e);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
@@ -142,18 +143,19 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		LanguageServiceAccessor.startLanguageServer(definition);
 	}
 
-	static void showVersionMismatchDialog(int expected, int actual) {
+	static void showIncompatibleCliDialog(int expected, int actual) {
 		if (!PlatformUI.isWorkbenchRunning()) return;
 		Display display = PlatformUI.getWorkbench().getDisplay();
+		String actualStr = actual >= 0 ? String.valueOf(actual) : "unknown";
 		display.asyncExec(() -> new MessageDialog(display.getActiveShell(),
 				"Snyk CLI version incompatible", null,
 				"",
-				MessageDialog.ERROR, new String[] { "OK" }, 0) {
+				MessageDialog.WARNING, new String[] { "OK" }, 0) {
 			@Override
 			protected Control createCustomArea(Composite parent) {
 				Link link = new Link(parent, SWT.WRAP);
 				link.setText("Your Snyk CLI version is incompatible with this Snyk plugin. "
-						+ "This Snyk plugin requires expected: " + expected + " vs actual: " + actual + ". "
+						+ "This Snyk plugin requires expected: " + expected + " vs actual: " + actualStr + ". "
 						+ "Upgrade the Snyk CLI or enable automatic updates in Snyk plugin settings. "
 						+ "For a list of compatible CLI versions, visit the "
 						+ "<a href=\"https://docs.snyk.io/developer-tools/snyk-ide-plugins-and-extensions"

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -138,18 +138,19 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		}
 	}
 
-	public static void startSnykLanguageServer() {
+	public static boolean startSnykLanguageServer() {
 		Preferences prefs = Preferences.getInstance();
 		try {
 			String cliPath = getCliPathOrThrow(prefs);
 			verifyCliProtocolVersion(cliPath);
 		} catch (IOException e) {
 			SnykLogger.logInfo("Not starting Snyk Language Server: " + e.getMessage());
-			return;
+			return false;
 		}
 		LanguageServerDefinition definition = LanguageServersRegistry.getInstance()
 				.getDefinition(SnykLanguageServer.LANGUAGE_SERVER_ID);
 		LanguageServiceAccessor.startLanguageServer(definition);
+		return true;
 	}
 
 	static void showIncompatibleCliDialog(int expected, int actual) {

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -78,7 +78,7 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 					+ "'snyk language-server --protocolVersion' did not return a version number "
 					+ "(got: '" + truncated + "'). Please update the Snyk CLI.";
 			SnykLogger.logAndShowError(msg);
-			throw new IOException(msg);
+			throw new IOException(msg, e);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			SnykLogger.logInfo("CLI protocol version check interrupted.");

--- a/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
+++ b/plugin/src/main/java/io/snyk/languageserver/SnykLanguageServer.java
@@ -80,9 +80,8 @@ public class SnykLanguageServer extends ProcessStreamConnectionProvider implemen
 		} catch (NumberFormatException e) {
 			int expected = Integer.parseInt(io.snyk.languageserver.download.LsBinaries.REQUIRED_LS_PROTOCOL_VERSION);
 			showIncompatibleCliDialog(expected, -1);
-			String truncated = output.length() > 40 ? output.substring(0, 40) + "..." : output;
-			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible: "
-					+ "'--protocolVersion' gave unexpected output (got: '" + truncated + "'). Please update the Snyk CLI.";
+			SnykLogger.logDebug("verifyCliProtocolVersion: unexpected output: " + output);
+			String msg = "Snyk CLI binary at '" + cliPath + "' is not compatible with this version of the Eclipse plugin. Please update the Snyk CLI.";
 			throw new IOException(msg, e);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
+++ b/plugin/src/main/java/io/snyk/languageserver/protocolextension/SnykExtendedLanguageClient.java
@@ -269,7 +269,9 @@ public class SnykExtendedLanguageClient extends LanguageClientImpl {
 			}
 
 			try {
-				SnykLanguageServer.startSnykLanguageServer();
+				if (!SnykLanguageServer.startSnykLanguageServer()) {
+					break;
+				}
 			} catch (Exception e) {
 				SnykLogger.logError(e);
 			}

--- a/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
@@ -1,6 +1,7 @@
 package io.snyk.languageserver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -158,19 +159,55 @@ class SnykLanguageServerTest extends LsBaseTest {
   }
 
   @Test
-  void verifyCliProtocolVersion_doesNotThrowOnUnparseableOutput() throws Exception {
+  void verifyCliProtocolVersion_throwsWithClearMessageOnUnparseableOutput() throws Exception {
     assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"),
         "Shell script not supported on Windows");
     File script = createCliStub("not-a-number");
 
+    IOException ex = assertThrows(IOException.class,
+        () -> SnykLanguageServer.verifyCliProtocolVersion(script.getAbsolutePath()));
+
+    assertTrue(ex.getMessage().contains("not compatible"), "Should say binary is not compatible");
+    assertFalse(ex.getMessage().contains("NumberFormatException"), "Should not expose internal exception type");
+  }
+
+  @Test
+  void verifyCliProtocolVersion_throwsWithTruncatedOutputNotFullHelpText() throws Exception {
+    assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"),
+        "Shell script not supported on Windows");
+    // Simulate an old CLI that outputs a very long message (90+ chars) instead of a version number.
+    // Using a simple safe string to avoid shell escaping issues.
+    String longOutput = "This is not a version number and it is deliberately very long output text here abcdefghijklmno";
+    File script = createCliStub(longOutput);
+
+    IOException ex = assertThrows(IOException.class,
+        () -> SnykLanguageServer.verifyCliProtocolVersion(script.getAbsolutePath()));
+
+    assertTrue(ex.getMessage().length() < 300, "Error message should be short, not dump full help text");
+    assertTrue(ex.getMessage().contains("..."), "Long output should be truncated with ellipsis");
+  }
+
+  @Test
+  void verifyCliProtocolVersion_parsesVersionFromFirstLineIgnoringTrailingOutput() throws Exception {
+    assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"),
+        "Shell script not supported on Windows");
+    // Simulate a CLI that prints version on first line then a warning on the second line.
+    File script = File.createTempFile("snyk-cli-stub", ".sh");
+    script.deleteOnExit();
+    Files.writeString(script.toPath(),
+        "#!/bin/sh\nprintf '" + LsBinaries.REQUIRED_LS_PROTOCOL_VERSION + "\\nWarning: something deprecated\\n'\n");
+    Files.setPosixFilePermissions(script.toPath(),
+        Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE));
+
+    // Should succeed — version is on the first line and matches.
     SnykLanguageServer.verifyCliProtocolVersion(script.getAbsolutePath());
   }
 
   @Test
   @Tag("smoke")
-  // The --protocolVersion flag is not yet in released CLI builds, so the real binary
-  // returns unparseable output. verifyCliProtocolVersion() must treat that as non-fatal.
-  void verifyCliProtocolVersion_withRealCliDownload_doesNotThrowWhenFlagUnknown() throws Exception {
+  // The real downloaded CLI supports --protocolVersion; verify the check passes against it.
+  void verifyCliProtocolVersion_withRealCliDownload_passesWhenVersionSupported() throws Exception {
     assumeTrue(isNetworkAvailable(), "Network not available — skipping smoke test");
 
     File tempBinary = File.createTempFile("snyk-cli-smoke", "");
@@ -181,6 +218,7 @@ class SnykLanguageServerTest extends LsBaseTest {
       LsRuntimeEnvironment realEnv = new LsRuntimeEnvironment();
       LsDownloader downloader = new LsDownloader(HttpClientFactory.getInstance(), realEnv, null);
       downloader.download(new NullProgressMonitor());
+      // The downloaded CLI must support --protocolVersion and return the required version.
       SnykLanguageServer.verifyCliProtocolVersion(tempBinary.getAbsolutePath());
     } finally {
       prefs.store(Preferences.CLI_PATH, originalCliPath);

--- a/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
@@ -172,19 +172,16 @@ class SnykLanguageServerTest extends LsBaseTest {
   }
 
   @Test
-  void verifyCliProtocolVersion_throwsWithTruncatedOutputNotFullHelpText() throws Exception {
+  void verifyCliProtocolVersion_throwsWithoutRawOutputInMessage() throws Exception {
     assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"),
         "Shell script not supported on Windows");
-    // Simulate an old CLI that outputs a very long message (90+ chars) instead of a version number.
-    // Using a simple safe string to avoid shell escaping issues.
     String longOutput = "This is not a version number and it is deliberately very long output text here abcdefghijklmno";
     File script = createCliStub(longOutput);
 
     IOException ex = assertThrows(IOException.class,
         () -> SnykLanguageServer.verifyCliProtocolVersion(script.getAbsolutePath()));
 
-    assertTrue(ex.getMessage().length() < 300, "Error message should be short, not dump full help text");
-    assertTrue(ex.getMessage().contains("..."), "Long output should be truncated with ellipsis");
+    assertFalse(ex.getMessage().contains("This is not a version number"), "Raw output must not appear in user-facing message");
   }
 
   @Test

--- a/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
+++ b/tests/src/test/java/io/snyk/languageserver/SnykLanguageServerTest.java
@@ -202,6 +202,27 @@ class SnykLanguageServerTest extends LsBaseTest {
   }
 
   @Test
+  void startSnykLanguageServer_returnsFalse_whenCliNotFound() {
+    this.prefs.store(Preferences.CLI_PATH, NON_EXISTENT_CLI_PATH);
+
+    boolean result = SnykLanguageServer.startSnykLanguageServer();
+
+    assertFalse(result, "Should return false when CLI binary does not exist");
+  }
+
+  @Test
+  void startSnykLanguageServer_returnsFalse_whenProtocolVersionMismatches() throws Exception {
+    assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"),
+        "Shell script not supported on Windows");
+    File script = createCliStub("999");
+    this.prefs.store(Preferences.CLI_PATH, script.getAbsolutePath());
+
+    boolean result = SnykLanguageServer.startSnykLanguageServer();
+
+    assertFalse(result, "Should return false when CLI protocol version mismatches");
+  }
+
+  @Test
   @Tag("smoke")
   // The real downloaded CLI supports --protocolVersion; verify the check passes against it.
   void verifyCliProtocolVersion_withRealCliDownload_passesWhenVersionSupported() throws Exception {


### PR DESCRIPTION
## Summary

- Adds `verifyCliProtocolVersion()` check **before** invoking lsp4e, so an incompatible CLI no longer triggers the generic Eclipse "Problem Occurred" dialog
- `startSnykLanguageServer()` now returns `boolean`; callers gate downstream behaviour on it
- Snyk Wizard is suppressed when the CLI check fails — no point authenticating against a non-functional LS
- `ensureLanguageServerRunning()` retry loop breaks immediately on `false` return, preventing repeated incompatibility dialogs every second
- Dialog message uses plain language ("requires protocol version X, but installed CLI reports version Y") instead of leaking variable names
- Raw CLI output and NFE cause chain kept out of user-facing messages (debug-only logging)

## Test plan

- [ ] Install plugin from update site built on this branch (`file:///Users/skippy/repos/snyk-eclipse-plugin2/update-site/target/repository`)
- [ ] Point CLI path to an incompatible binary (wrong protocol version) → verify single "Snyk CLI version incompatible" dialog with compatibility-matrix link, no "Problem Occurred" dialog, no Snyk Wizard
- [ ] Point CLI path to a non-existent path → verify "binary not found" error, no wizard
- [ ] Point CLI path to a valid compatible CLI → verify normal startup + wizard (if unauthenticated)
- [ ] Verify clicking the compatibility-matrix link in the dialog opens the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)