### PR TITLE
feat(settings): wire global additional_environment into LsSettingsRegistry [IDE-2110]

### DIFF
--- a/plugin/src/main/java/io/snyk/languageserver/LsKey.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsKey.java
@@ -11,7 +11,6 @@ public enum LsKey {
     INSECURE("proxy_insecure"),
     ADDITIONAL_PARAMS("additional_parameters"),
     SCANNING_MODE("scan_automatic"),
-    /** Not in ENTRIES — global scope not yet implemented; folder-scoped env uses LsFolderSettingsKeys.ADDITIONAL_ENV. */
     ADDITIONAL_ENV("additional_environment"),
     SEND_ERROR_REPORTS("send_error_reports"),
     /** Not in ENTRIES — superseded by SEND_ERROR_REPORTS; retained for backward compatibility with stored prefs. */

--- a/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
+++ b/plugin/src/main/java/io/snyk/languageserver/LsSettingsRegistry.java
@@ -139,6 +139,7 @@ public final class LsSettingsRegistry {
         entries.put(LsKey.CLI_BASE_DOWNLOAD_URL,  Entry.fallback(LsKey.CLI_BASE_DOWNLOAD_URL, Preferences.CLI_BASE_URL, Preferences.DEFAULT_CLI_BASE_URL));
         entries.put(LsKey.INSECURE,               Entry.boolFallback(LsKey.INSECURE, Preferences.INSECURE_KEY, false));
         entries.put(LsKey.ADDITIONAL_PARAMS,      Entry.simple(LsKey.ADDITIONAL_PARAMS, Preferences.ADDITIONAL_PARAMETERS, ""));
+        entries.put(LsKey.ADDITIONAL_ENV,         Entry.simple(LsKey.ADDITIONAL_ENV, Preferences.ADDITIONAL_ENVIRONMENT, ""));
         entries.put(LsKey.ENABLE_TRUSTED_FOLDERS_FEATURE, Entry.fixed(LsKey.ENABLE_TRUSTED_FOLDERS_FEATURE, Boolean.TRUE.toString()));
         entries.put(LsKey.ISSUE_VIEW_OPEN_ISSUES, Entry.bool(LsKey.ISSUE_VIEW_OPEN_ISSUES, Preferences.FILTER_IGNORES_SHOW_OPEN_ISSUES, true));
         entries.put(LsKey.ISSUE_VIEW_IGNORED_ISSUES, Entry.bool(LsKey.ISSUE_VIEW_IGNORED_ISSUES, Preferences.FILTER_IGNORES_SHOW_IGNORED_ISSUES, false));

--- a/tests/src/test/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePageTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/preferences/HTMLSettingsPreferencePageTest.java
@@ -198,6 +198,24 @@ class HTMLSettingsPreferencePageTest {
 	}
 
 	@Test
+	void parseAndSaveConfig_savesGlobalAdditionalParameters() throws Exception {
+		String json = "{\"additional_parameters\": \"--severity-threshold=high --debug\"}";
+
+		invokeParseAndSaveConfig(json);
+
+		assertEquals("--severity-threshold=high --debug", prefs.getPref(Preferences.ADDITIONAL_PARAMETERS));
+	}
+
+	@Test
+	void parseAndSaveConfig_savesGlobalAdditionalEnvironment() throws Exception {
+		String json = "{\"additional_environment\": \"VAR1=value1;VAR2=value2\"}";
+
+		invokeParseAndSaveConfig(json);
+
+		assertEquals("VAR1=value1;VAR2=value2", prefs.getPref(Preferences.ADDITIONAL_ENVIRONMENT));
+	}
+
+	@Test
 	void parseAndSaveConfig_handlesMultipleSettings() throws Exception {
 		String json = "{\"cli_path\": \"/custom/path\", \"organization\": \"test-org\", \"proxy_insecure\": true}";
 


### PR DESCRIPTION
## Summary

- Adds `additional_environment` (global/Project Defaults scope) to `LsSettingsRegistry.ENTRIES` alongside the existing `additional_parameters` entry
- Removes stale comment on `LsKey.ADDITIONAL_ENV` that said global scope was not yet implemented
- Adds tests for global `additional_parameters` and `additional_environment` persist via `parseAndSaveConfig`

Adding to `ENTRIES` fixes all three derived paths at once: outbound (`LsConfigurationUpdater`), inbound persist (`HTMLSettingsPreferencePage` global loop via `BY_LS_KEY`), and `buildConfigurationParam`.

Completes the IDE-side wiring for snyk-ls PR #1340 (IDE-2110) which added both settings to the Project Defaults tab of the HTML settings dialog.

## Test plan

- [ ] `HTMLSettingsPreferencePageTest` passes (both new global round-trip cases)
- [ ] `./mvnw -pl plugin,tests verify` green
- [ ] `./mvnw pmd:check` clean
- [ ] Manual: open Settings → Project Defaults → Advanced; set additional_environment (`VAR1=a;VAR2=b`); save; reopen — field repopulates