### PR TITLE
fix: fix html styling to match native theme and stop flickering during scans.

### DIFF
--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,7 +41,7 @@ public class BaseHtmlProvider {
 	// user switches Eclipse light↔dark at runtime those caches go stale. A global generation counter is
 	// bumped on theme change; each instance lazily clears its caches when it sees a newer generation, so
 	// the next render re-resolves foreground/border/etc. from the new theme (not just the background).
-	private static volatile int themeGeneration;
+	private static final AtomicInteger themeGeneration = new AtomicInteger();
 	private volatile int cacheGeneration;
 
 	public static void setIdeBackgroundColorHex(String hex) {
@@ -53,7 +54,7 @@ public class BaseHtmlProvider {
 
 	/** Signals that the Eclipse theme changed; cached theme colors are re-resolved on the next render. */
 	public static void invalidateThemeCaches() {
-		themeGeneration++;
+		themeGeneration.incrementAndGet();
 	}
 
 
@@ -409,7 +410,7 @@ public class BaseHtmlProvider {
 		if (Preferences.getInstance().isTest()) {
 			return;
 		}
-		int currentGeneration = themeGeneration;
+		int currentGeneration = themeGeneration.get();
 		if (cacheGeneration == currentGeneration) {
 			return;
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -28,13 +28,26 @@ public class BaseHtmlProvider {
 	private final Map<String, String> colorCache = new HashMap<>();
 	private String nonce = "";
 
+	// The actual themed view background, captured from an SWT control that the e4 CSS engine has
+	// styled (see SnykToolView). This is the true "Eclipse grey" for the view content area — the tab
+	// color keys used below resolve to the lighter tab-strip grey, which does not match adjacent views.
+	// Shared statically so every provider instance (tree/summary/detail) resolves the same background.
+	private static volatile String ideBackgroundColorHex;
+
+	public static void setIdeBackgroundColorHex(String hex) {
+		ideBackgroundColorHex = hex;
+	}
+
+	public static String getIdeBackgroundColorHex() {
+		return ideBackgroundColorHex;
+	}
+
 
 	// Eclipse theme color keys
 	private static final String THEME_INACTIVE_TAB_BG = "org.eclipse.ui.workbench.INACTIVE_TAB_BG_START";
 	private static final String THEME_ACTIVE_TAB_KEYLINE = "org.eclipse.ui.workbench.ACTIVE_TAB_OUTER_KEYLINE_COLOR";
 	private static final String THEME_ACTIVE_TAB_SELECTED_TEXT = "org.eclipse.ui.workbench.ACTIVE_TAB_SELECTED_TEXT_COLOR";
 	private static final String THEME_ACTIVE_TAB_TEXT = "org.eclipse.ui.workbench.ACTIVE_TAB_TEXT_COLOR";
-	private static final String THEME_ACTIVE_NOFOCUS_TAB_BG = "org.eclipse.ui.workbench.ACTIVE_NOFOCUS_TAB_BG_START";
 	private static final String THEME_ACTIVE_TAB_BG_END = "org.eclipse.ui.workbench.ACTIVE_TAB_BG_END";
 	private static final String THEME_ACTIVE_HYPERLINK = "ACTIVE_HYPERLINK_COLOR";
 	private static final String THEME_DARK_BACKGROUND = "org.eclipse.ui.workbench.DARK_BACKGROUND";
@@ -182,12 +195,16 @@ public class BaseHtmlProvider {
 
 		boolean dark = Boolean.TRUE.equals(isDarkTheme());
 
+		// The true Eclipse view background. Both --ide-background-color and --background-color resolve to
+		// this single value so every panel (tree/summary/detail) matches each other and the adjacent views.
+		String ideBg = getIdeBackgroundHex();
+
 		// Replace CSS variables with actual color values
 		htmlStyled = htmlStyled.replace(CSS_VAR_TEXT_COLOR, getColorAsHex(THEME_ACTIVE_TAB_SELECTED_TEXT, "#000000"));
 		htmlStyled = htmlStyled.replace(CSS_VAR_DIMMED_TEXT_COLOR, getColorAsHex(THEME_ACTIVE_TAB_TEXT, "#4F5456"));
 
-		htmlStyled = htmlStyled.replace(CSS_VAR_IDE_BACKGROUND_COLOR, getColorAsHex(THEME_ACTIVE_NOFOCUS_TAB_BG, DEFAULT_WHITE_COLOR));
-		htmlStyled = htmlStyled.replace(CSS_VAR_BACKGROUND_COLOR, getColorAsHex(THEME_ACTIVE_TAB_BG_END, DEFAULT_WHITE_COLOR));
+		htmlStyled = htmlStyled.replace(CSS_VAR_IDE_BACKGROUND_COLOR, ideBg);
+		htmlStyled = htmlStyled.replace(CSS_VAR_BACKGROUND_COLOR, ideBg);
 		htmlStyled = htmlStyled.replace(CSS_VAR_CODE_BACKGROUND_COLOR,
 				getColorAsHex(THEME_INACTIVE_TAB_BG, DEFAULT_SECTION_BG_COLOR));
 		htmlStyled = htmlStyled.replace(CSS_VAR_BUTTON_COLOR,
@@ -212,7 +229,7 @@ public class BaseHtmlProvider {
 		// Replace CSS variables used in LS-served HTML (settings page)
 		// Get Eclipse theme colors
 		String textColor = getColorAsHex(THEME_ACTIVE_TAB_SELECTED_TEXT, "#000000");
-		String bgColor = getColorAsHex(THEME_ACTIVE_TAB_BG_END, DEFAULT_WHITE_COLOR);
+		String bgColor = ideBg;
 		String inputBgColor = getColorAsHex(THEME_INACTIVE_TAB_BG, DEFAULT_SECTION_BG_COLOR);
 		String borderColor = getColorAsHex(THEME_ACTIVE_TAB_KEYLINE, DEFAULT_BORDER_COLOR);
 		String focusColor = getColorAsHex(THEME_ACTIVE_HYPERLINK, "#0066cc");
@@ -299,6 +316,11 @@ public class BaseHtmlProvider {
 		vsCodeVarMap.put("vscode-scrollbarSlider-background", inputBgColor);
 		vsCodeVarMap.put("vscode-scrollbarSlider-hoverBackground", adjustForHover(inputBgColor, dark));
 		vsCodeVarMap.put("vscode-scrollbarSlider-activeBackground", adjustBrightness(inputBgColor, dark ? 1.2f : 0.8f));
+		// Tree-view tooltips (.tree-tooltip) key off these. Without a mapping the CSS falls back to a
+		// hardcoded dark background (#252526), which is invisible/unreadable in the light theme.
+		vsCodeVarMap.put("vscode-editorHoverWidget-background", inputBgColor);
+		vsCodeVarMap.put("vscode-editorHoverWidget-foreground", textColor);
+		vsCodeVarMap.put("vscode-editorHoverWidget-border", borderColor);
 		htmlStyled = replaceRemainingCssVars(htmlStyled, vsCodeVarMap);
 
 		htmlStyled = htmlStyled.replace("${headerEnd}", "");
@@ -347,6 +369,20 @@ public class BaseHtmlProvider {
 
 		// CSS allows 3 decimal places of precision for calculations.
 		return String.format(Locale.ROOT, "%.3frem", targetSizePt / startingFontSizePt);
+	}
+
+	/**
+	 * Returns the true Eclipse view background as a hex string. Prefers the value captured from a
+	 * themed SWT control (set via {@link #setIdeBackgroundColorHex(String)}), which reflects the exact
+	 * grey the active theme paints view content with. Falls back to the tab-strip background key when no
+	 * control-derived value is available (e.g. before the view is created, or in test mode).
+	 */
+	public String getIdeBackgroundHex() {
+		String captured = ideBackgroundColorHex;
+		if (captured != null && !captured.isEmpty()) {
+			return captured;
+		}
+		return getColorAsHex(THEME_ACTIVE_TAB_BG_END, DEFAULT_WHITE_COLOR);
 	}
 
 	public String getColorAsHex(String colorKey, String defaultColor) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,12 +26,22 @@ import io.snyk.languageserver.protocolextension.messageObjects.PresentableError;
 
 public class BaseHtmlProvider {
 	private final Random random = new Random();
-	private final Map<String, String> colorCache = new HashMap<>();
+	// ConcurrentHashMap, not HashMap: the detail panel renders off the UI thread
+	// (BrowserHandler.updateBrowserContent → CompletableFuture.runAsync) against a shared singleton
+	// provider, so refreshThemeCachesIfStale's clear() can race getColorAsHex's computeIfAbsent.
+	private final Map<String, String> colorCache = new ConcurrentHashMap<>();
 	private String nonce = "";
 
 	// The native themed view background color from Eclipse.
 	// Shared statically so every provider instance (tree/summary/detail) resolves the same background.
 	private static volatile String ideBackgroundColorHex;
+
+	// Resolved theme colors are cached per instance (colorCache/colorRegistry/currentTheme). When the
+	// user switches Eclipse light↔dark at runtime those caches go stale. A global generation counter is
+	// bumped on theme change; each instance lazily clears its caches when it sees a newer generation, so
+	// the next render re-resolves foreground/border/etc. from the new theme (not just the background).
+	private static volatile int themeGeneration;
+	private volatile int cacheGeneration;
 
 	public static void setIdeBackgroundColorHex(String hex) {
 		ideBackgroundColorHex = hex;
@@ -38,6 +49,11 @@ public class BaseHtmlProvider {
 
 	public static String getIdeBackgroundColorHex() {
 		return ideBackgroundColorHex;
+	}
+
+	/** Signals that the Eclipse theme changed; cached theme colors are re-resolved on the next render. */
+	public static void invalidateThemeCaches() {
+		themeGeneration++;
 	}
 
 
@@ -178,6 +194,7 @@ public class BaseHtmlProvider {
 	}
 
 	public String replaceCssVariables(String html, boolean useRelativeFontSize) {
+		refreshThemeCachesIfStale();
 		// Build the CSS with the nonce
 		String nonce = getNonce();
 		String css = "<style nonce=\"" + nonce + "\">" + getCss() + "</style>";
@@ -381,6 +398,32 @@ public class BaseHtmlProvider {
 		return getColorAsHex(THEME_ACTIVE_TAB_BG_END, DEFAULT_WHITE_COLOR);
 	}
 
+	// Re-resolves this instance's cached theme colors if a theme change has been signalled since the
+	// last render, so subsequent getColorAsHex lookups reflect the current theme. Only re-fetches inside
+	// the branch (never taken until invalidateThemeCaches bumps the generation), so test renders — which
+	// have no running workbench — never call PlatformUI here.
+	private void refreshThemeCachesIfStale() {
+		// Test mode never resolves real colors (getColorAsHex short-circuits), and there is no workbench,
+		// so keep the PlatformUI call out of headless runs — self-enforcing rather than relying on the
+		// generation never being bumped in tests.
+		if (Preferences.getInstance().isTest()) {
+			return;
+		}
+		int currentGeneration = themeGeneration;
+		if (cacheGeneration == currentGeneration) {
+			return;
+		}
+		colorCache.clear();
+		ITheme freshTheme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
+		// Publish currentTheme/colorRegistry (both volatile) BEFORE the volatile cacheGeneration write, so
+		// a concurrent reader that observes the new generation is guaranteed to also see the new fields
+		// (happens-before via the cacheGeneration volatile). Writing the generation first would let a
+		// reader skip its own refresh and then read a stale registry.
+		currentTheme = freshTheme;
+		colorRegistry = freshTheme.getColorRegistry();
+		cacheGeneration = currentGeneration;
+	}
+
 	public String getColorAsHex(String colorKey, String defaultColor) {
 		if (Preferences.getInstance().isTest()) {
 			return "";
@@ -467,7 +510,9 @@ public class BaseHtmlProvider {
 		return !darkColor.isEmpty();
 	}
 
-	private ColorRegistry colorRegistry;
+	// volatile: reassigned from a background render thread in refreshThemeCachesIfStale and read from
+	// other threads via getColorRegistry/getColorAsHex.
+	private volatile ColorRegistry colorRegistry;
 
 	private ColorRegistry getColorRegistry() {
 		if (colorRegistry != null) {
@@ -478,7 +523,8 @@ public class BaseHtmlProvider {
 		return colorRegistry;
 	}
 
-	private ITheme currentTheme;
+	// volatile: see colorRegistry — reassigned from a background render thread and read from others.
+	private volatile ITheme currentTheme;
 
 	public ITheme getCurrentTheme() {
 		if (currentTheme != null) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -413,14 +413,15 @@ public class BaseHtmlProvider {
 		if (cacheGeneration == currentGeneration) {
 			return;
 		}
-		colorCache.clear();
 		ITheme freshTheme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
-		// Publish currentTheme/colorRegistry (both volatile) BEFORE the volatile cacheGeneration write, so
-		// a concurrent reader that observes the new generation is guaranteed to also see the new fields
-		// (happens-before via the cacheGeneration volatile). Writing the generation first would let a
-		// reader skip its own refresh and then read a stale registry.
+		// Order matters:
+		// 1. Swap currentTheme/colorRegistry (both volatile) to the new theme first.
+		// 2. Call clear() after the swap, so a stale inserted against the old registry (in the
+        //    window before the swap) is wiped.
+		// 3. Bump the volatile cacheGeneration last, so readers are guaranteed to see the new fields.
 		currentTheme = freshTheme;
 		colorRegistry = freshTheme.getColorRegistry();
+		colorCache.clear();
 		cacheGeneration = currentGeneration;
 	}
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/BaseHtmlProvider.java
@@ -28,9 +28,7 @@ public class BaseHtmlProvider {
 	private final Map<String, String> colorCache = new HashMap<>();
 	private String nonce = "";
 
-	// The actual themed view background, captured from an SWT control that the e4 CSS engine has
-	// styled (see SnykToolView). This is the true "Eclipse grey" for the view content area — the tab
-	// color keys used below resolve to the lighter tab-strip grey, which does not match adjacent views.
+	// The native themed view background color from Eclipse.
 	// Shared statically so every provider instance (tree/summary/detail) resolves the same background.
 	private static volatile String ideBackgroundColorHex;
 
@@ -316,8 +314,7 @@ public class BaseHtmlProvider {
 		vsCodeVarMap.put("vscode-scrollbarSlider-background", inputBgColor);
 		vsCodeVarMap.put("vscode-scrollbarSlider-hoverBackground", adjustForHover(inputBgColor, dark));
 		vsCodeVarMap.put("vscode-scrollbarSlider-activeBackground", adjustBrightness(inputBgColor, dark ? 1.2f : 0.8f));
-		// Tree-view tooltips (.tree-tooltip) key off these. Without a mapping the CSS falls back to a
-		// hardcoded dark background (#252526), which is invisible/unreadable in the light theme.
+		// Used by Tree-view tooltips (.tree-tooltip)
 		vsCodeVarMap.put("vscode-editorHoverWidget-background", inputBgColor);
 		vsCodeVarMap.put("vscode-editorHoverWidget-foreground", textColor);
 		vsCodeVarMap.put("vscode-editorHoverWidget-border", borderColor);
@@ -373,8 +370,7 @@ public class BaseHtmlProvider {
 
 	/**
 	 * Returns the true Eclipse view background as a hex string. Prefers the value captured from a
-	 * themed SWT control (set via {@link #setIdeBackgroundColorHex(String)}), which reflects the exact
-	 * grey the active theme paints view content with. Falls back to the tab-strip background key when no
+	 * themed SWT control, but falls back to the tab-strip background key when no
 	 * control-derived value is available (e.g. before the view is created, or in test mode).
 	 */
 	public String getIdeBackgroundHex() {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProvider.java
@@ -1,0 +1,22 @@
+package io.snyk.eclipse.plugin.html;
+
+/**
+ * HTML provider for the Snyk tree view. Adds tree-specific CSS on top of {@link BaseHtmlProvider}'s
+ * theme-variable substitution.
+ *
+ * <p>The feedback banner link ({@code .feedback-banner-link} in the LS-served styles.css) uses
+ * {@code var(--button-text-color)}, which resolves to the button foreground — black in the dark theme
+ * (readable on a light button, but not on the banner's dark gradient). That variable is shared with the
+ * real action buttons, so it cannot be re-substituted globally without breaking them; the fix has to be
+ * element-scoped. This CSS is injected via the {@code ${ideStyle}} slot, which lands after the LS styles
+ * so it wins by cascade order, and the emitted {@code var(--text-color)} is resolved by
+ * {@link BaseHtmlProvider#replaceCssVariables} to the themed text color (white in dark, dark in light),
+ * matching the banner's own text.
+ */
+public class TreeViewHtmlProvider extends BaseHtmlProvider {
+
+	@Override
+	public String getCss() {
+		return ".feedback-banner-link { color: var(--text-color); }";
+	}
+}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProvider.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProvider.java
@@ -12,11 +12,18 @@ package io.snyk.eclipse.plugin.html;
  * so it wins by cascade order, and the emitted {@code var(--text-color)} is resolved by
  * {@link BaseHtmlProvider#replaceCssVariables} to the themed text color (white in dark, dark in light),
  * matching the banner's own text.
+ *
+ * <p>TEMPORARY / plugin-side workaround. The proper fix belongs in snyk-ls: give the feedback-banner
+ * link its own CSS variable (or a readable-on-gradient value) instead of reusing the shared
+ * {@code --button-text-color}, so every IDE benefits and none needs this element-scoped override.
+ * Tracked as tech debt — remove this override once the LS emits a correct banner link color.
  */
 public class TreeViewHtmlProvider extends BaseHtmlProvider {
 
 	@Override
 	public String getCss() {
+		// TODO(tech-debt): remove once snyk-ls gives the feedback-banner link its own readable color
+		// variable rather than the shared --button-text-color. See the class javadoc.
 		return ".feedback-banner-link { color: var(--text-color); }";
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserFlashGuard.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserFlashGuard.java
@@ -13,6 +13,8 @@ import org.eclipse.swt.browser.ProgressEvent;
  */
 final class BrowserFlashGuard {
 	private static final int SAFETY_REVEAL_MS = 1500;
+	// Widget-data key holding the single reusable reveal Runnable per browser (see rescheduleSafetyReveal).
+	private static final String REVEAL_KEY = "snyk.flashGuardReveal";
 
 	private BrowserFlashGuard() {
 	}
@@ -39,7 +41,7 @@ final class BrowserFlashGuard {
 		if (browser == null || browser.isDisposed()) {
 			return;
 		}
-		browser.getDisplay().timerExec(SAFETY_REVEAL_MS, () -> reveal(browser));
+		rescheduleSafetyReveal(browser);
 	}
 
 	/**
@@ -52,7 +54,30 @@ final class BrowserFlashGuard {
 		}
 		browser.setVisible(false);
 		browser.setText(html);
-		browser.getDisplay().timerExec(SAFETY_REVEAL_MS, () -> reveal(browser));
+		rescheduleSafetyReveal(browser);
+	}
+
+	/**
+	 * Cancels any pending safety-reveal for this browser and schedules a fresh one. SWT's timerExec
+	 * cancels by Runnable identity, so a single reusable Runnable per browser is reused — otherwise a
+	 * fresh lambda per call would let timers stack, and a stale one could fire mid-load of a later
+	 * document and reveal the browser before it is ready (notably on the summary panel, which re-hides
+	 * on every changed render).
+	 */
+	private static void rescheduleSafetyReveal(Browser browser) {
+		Runnable revealTask = revealRunnable(browser);
+		browser.getDisplay().timerExec(-1, revealTask);
+		browser.getDisplay().timerExec(SAFETY_REVEAL_MS, revealTask);
+	}
+
+	private static Runnable revealRunnable(Browser browser) {
+		Object existing = browser.getData(REVEAL_KEY);
+		if (existing instanceof Runnable) {
+			return (Runnable) existing;
+		}
+		Runnable revealTask = () -> reveal(browser);
+		browser.setData(REVEAL_KEY, revealTask);
+		return revealTask;
 	}
 
 	private static void reveal(Browser browser) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserFlashGuard.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserFlashGuard.java
@@ -1,0 +1,63 @@
+package io.snyk.eclipse.plugin.views.snyktoolview;
+
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.ProgressAdapter;
+import org.eclipse.swt.browser.ProgressEvent;
+
+/**
+ * Reduces the white flash the SWT Browser shows while a new document loads. On macOS the Browser uses
+ * the legacy Cocoa WebView, which paints opaque white between documents and exposes no API to set a
+ * native/page background. To avoid a jarring white flash (especially in dark mode) the browser is
+ * hidden immediately before {@code setText} — so its panel-colored wrapper composite shows through
+ * instead of white — and revealed again once the load completes.
+ */
+final class BrowserFlashGuard {
+	private static final int SAFETY_REVEAL_MS = 1500;
+
+	private BrowserFlashGuard() {
+	}
+
+	/** Installs a permanent listener that reveals the browser once each document load completes. */
+	static void install(Browser browser) {
+		if (browser == null || browser.isDisposed()) {
+			return;
+		}
+		browser.addProgressListener(new ProgressAdapter() {
+			@Override
+			public void completed(ProgressEvent event) {
+				reveal(browser);
+			}
+		});
+	}
+
+	/**
+	 * Reveals the browser once, after its first load. Use for panels that must stay interactive while
+	 * they refresh (e.g. the issue tree during a scan): the browser is hidden only for the initial
+	 * cold-open load and is never hidden again, so clicks are never swallowed by a hidden control.
+	 */
+	static void scheduleSafetyReveal(Browser browser) {
+		if (browser == null || browser.isDisposed()) {
+			return;
+		}
+		browser.getDisplay().timerExec(SAFETY_REVEAL_MS, () -> reveal(browser));
+	}
+
+	/**
+	 * Hides the browser, loads the HTML, and schedules a safety reveal so the panel can never get stuck
+	 * hidden if the completed event does not fire.
+	 */
+	static void setTextFlashSafe(Browser browser, String html) {
+		if (browser == null || browser.isDisposed() || html == null) {
+			return;
+		}
+		browser.setVisible(false);
+		browser.setText(html);
+		browser.getDisplay().timerExec(SAFETY_REVEAL_MS, () -> reveal(browser));
+	}
+
+	private static void reveal(Browser browser) {
+		if (browser != null && !browser.isDisposed() && !browser.getVisible()) {
+			browser.setVisible(true);
+		}
+	}
+}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
@@ -31,14 +31,13 @@ import io.snyk.eclipse.plugin.utils.SnykLogger;
 import io.snyk.eclipse.plugin.views.snyktoolview.handlers.HandlerCommands;
 import io.snyk.eclipse.plugin.wizards.SnykWizard;
 import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
+import io.snyk.languageserver.protocolextension.messageObjects.PresentableError;
 
 @SuppressWarnings("restriction")
 public class BrowserHandler {
 	private static final int validNumberOfArguments = 5;
 	private Browser browser;
 	private String initScript = "";
-	// How to re-render whatever is currently shown, so the panel can adopt a newly-resolved theme
-	// color once the CSS engine has styled the view. Re-running re-substitutes the color variables.
 	private Runnable currentRenderer;
 
 	public BrowserHandler(Browser browser) {
@@ -203,9 +202,12 @@ public class BrowserHandler {
 		BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getScanningHtml());
 	}
 
-	public void setBrowserText(String html) {
-		currentRenderer = () -> setBrowserText(html);
-		BrowserFlashGuard.setTextFlashSafe(browser, html);
+	public void setErrorBrowserText(PresentableError error) {
+		// Store the error (not the rendered HTML) so refreshTheme() rebuilds via getErrorHtml, which
+		// re-runs replaceCssVariables and picks up a newly-resolved theme color. Rendering pre-resolved
+		// HTML here would freeze the error page at whatever color was current when it first displayed.
+		currentRenderer = () -> setErrorBrowserText(error);
+		BrowserFlashGuard.setTextFlashSafe(browser, new BaseHtmlProvider().getErrorHtml(error));
 	}
 
 	/** Re-renders the current content so it adopts a newly-resolved theme color. */

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
@@ -37,6 +37,9 @@ public class BrowserHandler {
 	private static final int validNumberOfArguments = 5;
 	private Browser browser;
 	private String initScript = "";
+	// How to re-render whatever is currently shown, so the panel can adopt a newly-resolved theme
+	// color once the CSS engine has styled the view. Re-running re-substitutes the color variables.
+	private Runnable currentRenderer;
 
 	public BrowserHandler(Browser browser) {
 		this.browser = browser;
@@ -158,11 +161,14 @@ public class BrowserHandler {
 			}
 		});
 
+		BrowserFlashGuard.install(browser);
+
 		setDefaultBrowserText();
 	}
 
 
 	public void updateBrowserContent(String issueId, String product) {
+		currentRenderer = () -> updateBrowserContent(issueId, product);
 		CompletableFuture.runAsync(() -> {
 			String displayed = ProductConstants.PRODUCT_TO_DISPLAYED.get(product);
 			BaseHtmlProvider htmlProvider = displayed != null ? HtmlProviderFactory.GetHtmlProvider(displayed) : null;
@@ -176,30 +182,37 @@ public class BrowserHandler {
 			}
 			final var browserContent = htmlProvider.replaceCssVariables(htmlContent);
 			Display.getDefault().syncExec(() -> {
-				if (!browser.isDisposed()) {
-					browser.setText(browserContent);
-				}
+				BrowserFlashGuard.setTextFlashSafe(browser, browserContent);
 			});
 		});
 	}
 
 	public void setDefaultBrowserText() {
+		currentRenderer = this::setDefaultBrowserText;
 		// If we are not authenticated, show the welcome page, else show the issue
 		// placeholder.
 		if (!Preferences.getInstance().isAuthenticated()) {
-			browser.setText(StaticPageHtmlProvider.getInstance().getInitHtml());
+			BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getInitHtml());
 		} else {
-			browser.setText(StaticPageHtmlProvider.getInstance().getDefaultHtml());
+			BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getDefaultHtml());
 		}
 	}
 
 	public void setScanningBrowserText() {
-		browser.setText(StaticPageHtmlProvider.getInstance().getScanningHtml());
+		currentRenderer = this::setScanningBrowserText;
+		BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getScanningHtml());
 	}
 
 	public void setBrowserText(String html) {
-		if (!browser.isDisposed()) {
-			browser.setText(html);
+		currentRenderer = () -> setBrowserText(html);
+		BrowserFlashGuard.setTextFlashSafe(browser, html);
+	}
+
+	/** Re-renders the current content so it adopts a newly-resolved theme color. */
+	public void refreshTheme() {
+		if (browser == null || browser.isDisposed() || currentRenderer == null) {
+			return;
 		}
+		currentRenderer.run();
 	}
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/BrowserHandler.java
@@ -167,6 +167,10 @@ public class BrowserHandler {
 
 
 	public void updateBrowserContent(String issueId, String product) {
+		// currentRenderer re-runs this method on refreshTheme(), which re-fetches the issue description
+		// from the language server (getIssueDescription below) rather than doing a cheap local re-render.
+		// That is acceptable only because refreshTheme fires on a rare user action (a theme switch); if
+		// theme-change frequency ever increases, cache the raw HTML and re-run only replaceCssVariables.
 		currentRenderer = () -> updateBrowserContent(issueId, product);
 		CompletableFuture.runAsync(() -> {
 			String displayed = ProductConstants.PRODUCT_TO_DISPLAYED.get(product);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -57,16 +57,20 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	private volatile TreeViewBrowserHandler treeBrowserHandler;
 	private final AtomicReference<String> pendingHtml = new AtomicReference<>();
 	private static final int TREE_RENDER_DEBOUNCE_MS = 150;
+	private static final int TREE_RENDER_MAX_WAIT_MS = 600;
 	private static final String SASH_PAINTER_KEY = "snyk.sashPainter";
 	private final Runnable treeRenderRunnable = this::renderPendingTreeHtml;
+	// Wall-clock (ms) of the oldest tree update still waiting to render; 0 when nothing is pending.
+	// Only accessed on the UI thread (scheduleTreeRender / renderPendingTreeHtml).
+	private long firstPendingSince;
 
 	@Override
 	public void createPartControl(Composite parent) {
 		this.rootComposite = parent;
 
-		// Best-effort background so the first render is not white. The e4 CSS engine styles the parent
-		// (to the same grey as native trees/views) only after createPartControl returns, so this initial
-		// read may be pre-theme; captureThemeBackgroundDeferred() below re-reads once styling is applied.
+		// Best-effort background so the first render is less jarring (e.g., don't use white
+        // backgrounds in dark mode) if the theme has not loaded yet;
+        // captureThemeBackgroundDeferred() below re-reads once styling is applied.
 		Color viewBackground = parent.getBackground();
 		BaseHtmlProvider.setIdeBackgroundColorHex(toHex(viewBackground));
 
@@ -81,9 +85,9 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		// Sashes get a contrasting shade so the dividers between panels stay visible.
 		applySashColor(viewBackground);
 
-		// Each browser sits in a panel-colored wrapper. While a browser is hidden during a reload, the
-		// wrapper shows through in the panel color instead of the browser's opaque-white default — so a
-		// refresh reads as a brief dark (invisible in dark mode) transition rather than a white flash.
+		// Each browser sits in a panel-colored wrapper. This means that the panel's background
+        // is used between HTML reloads, rather than the default white. This avoids flickering
+        // and white flashes when the HTML is loading and Eclipse is in dark mode.
 		summaryPane = wrapperComposite(verticalSashForm, viewBackground);
 		summaryBrowser = new Browser(summaryPane, SWT.EDGE);
 		applyBackground(summaryBrowser, viewBackground);
@@ -113,17 +117,16 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 
 		horizontalSashForm.setWeights(1, 2);
 
-		// Re-assert the sash color on resize: the theme's CSS can repaint the Sash controls the panel
-		// color again (e.g. on a reskin), and resize is the point at which that would become visible.
-		ControlListener sashRecolor = ControlListener.controlResizedAdapter(e -> {
-			colorSashes(horizontalSashForm, sashColor);
-			colorSashes(verticalSashForm, sashColor);
-		});
-		horizontalSashForm.addControlListener(sashRecolor);
-		verticalSashForm.addControlListener(sashRecolor);
+		// Recovery hook on resize: re-read the themed background and re-assert the sash color. This
+		// catches the case where the e4 CSS engine styles the view later than the two deferred capture
+		// attempts below (so the correct background is picked up on the next layout instead of being
+		// stuck at the pre-theme value), and re-asserts the divider color after a theme reskin.
+		ControlListener themeRecovery = ControlListener.controlResizedAdapter(e -> applyThemeColorsIfChanged());
+		horizontalSashForm.addControlListener(themeRecovery);
+		verticalSashForm.addControlListener(themeRecovery);
 
 		// Re-read the background after the CSS engine has styled the view, then re-render so every panel
-		// matches the native Eclipse grey (e.g. #2F2F2F in the dark theme).
+		// matches the native Eclipse theme.
 		captureThemeBackgroundDeferred();
 	}
 
@@ -204,23 +207,27 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	/**
 	 * Paints the SashForm dividers a contrasting shade of the panel background so they stay visible
 	 * (setting them to the panel color made them disappear). Owns the created Color and disposes the
-	 * previous one.
+	 * previous one. The Color is only recreated when the derived divider color actually changes, so
+	 * repeated calls (e.g. from the resize listener) do not churn Colors.
 	 */
 	private void applySashColor(Color panelBackground) {
 		if (panelBackground == null || rootComposite == null || rootComposite.isDisposed()) {
 			return;
 		}
-		Color previous = sashColor;
-		sashColor = createDividerColor(rootComposite.getDisplay(), panelBackground);
+		RGB dividerRgb = createDividerRgb(panelBackground.getRGB());
+		if (sashColor == null || sashColor.isDisposed() || !sashColor.getRGB().equals(dividerRgb)) {
+			Color previous = sashColor;
+			sashColor = new Color(rootComposite.getDisplay(), dividerRgb);
+			if (previous != null && !previous.isDisposed()) {
+				previous.dispose();
+			}
+		}
 		applyBackground(horizontalSashForm, sashColor);
 		applyBackground(verticalSashForm, sashColor);
 		// Also color the Sash child controls directly: the theme's `.MPart Sash` CSS rule paints them the
 		// panel color (making them invisible), overriding the SashForm composite background set above.
 		colorSashes(horizontalSashForm, sashColor);
 		colorSashes(verticalSashForm, sashColor);
-		if (previous != null && !previous.isDisposed()) {
-			previous.dispose();
-		}
 	}
 
 	private void colorSashes(SashForm form, Color color) {
@@ -230,10 +237,11 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		for (Control child : form.getChildren()) {
 			if (child instanceof Sash) {
 				child.setBackground(color);
-				// The theme's CSS repaints the Sash the panel color, and a plain setBackground does not
-				// survive its paint timing (the divider only appeared after the user interacted with it).
+
 				// Install a PaintListener that draws the divider color on top on every paint — this fires
-				// on the natural first paint when the view opens, so no interaction is needed.
+				// on the natural first paint when the view opens, meaning that dividers are always visible
+                // regardless of the theming, the order of the UI rendering, or whether the user has
+                // interacted with the Snyk panels.
 				if (child.getData(SASH_PAINTER_KEY) == null) {
 					child.setData(SASH_PAINTER_KEY, Boolean.TRUE);
 					child.addPaintListener(this::paintSash);
@@ -252,15 +260,14 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		event.gc.fillRectangle(0, 0, size.x, size.y);
 	}
 
-	/** Lightens a dark background / darkens a light one by a fixed step to yield a visible divider. */
-	private Color createDividerColor(Display display, Color background) {
-		RGB rgb = background.getRGB();
+	/** Lightens a dark background / darkens a light one by a fixed step to yield a visible divider RGB. */
+	private RGB createDividerRgb(RGB rgb) {
 		double luminance = (0.299 * rgb.red + 0.587 * rgb.green + 0.114 * rgb.blue) / 255.0;
 		int step = luminance < 0.5 ? 32 : -28;
 		int r = Math.min(255, Math.max(0, rgb.red + step));
 		int g = Math.min(255, Math.max(0, rgb.green + step));
 		int b = Math.min(255, Math.max(0, rgb.blue + step));
-		return new Color(display, r, g, b);
+		return new RGB(r, g, b);
 	}
 
 	@Override
@@ -282,8 +289,7 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 			if (param != null && SCAN_STATE_IN_PROGRESS.equals(param.getStatus())) {
 				this.browserHandler.setScanningBrowserText();
 			} else if (param != null && param.getPresentableError() != null) {
-				String errorHtml = new BaseHtmlProvider().getErrorHtml(param.getPresentableError());
-				this.browserHandler.setBrowserText(errorHtml);
+				this.browserHandler.setErrorBrowserText(param.getPresentableError());
 			} else {
 				this.browserHandler.setDefaultBrowserText();
 			}
@@ -361,17 +367,37 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		try {
 			Display display = Display.getDefault();
 			if (display != null && !display.isDisposed()) {
-				// Debounce: the LS pushes many tree-HTML updates during a scan and each reload flashes the
-				// browser. Rescheduling the same runnable coalesces a burst into a single render once the
-				// updates settle. timerExec must run on the UI thread, hence the asyncExec hop.
-				display.asyncExec(() -> display.timerExec(TREE_RENDER_DEBOUNCE_MS, treeRenderRunnable));
+				// timerExec must run on the UI thread; hop there first.
+				display.asyncExec(this::scheduleTreeRender);
 			}
 		} catch (SWTError | SWTException | UnsatisfiedLinkError | NoClassDefFoundError e) {
 			SnykLogger.logInfo("No SWT Display available, HTML will be drained on createPartControl: " + e.getMessage());
 		}
 	}
 
+	// Debounce tree reloads to reduce flicker during a scan, but with a max-wait ceiling: a sustained
+	// burst of updates arriving faster than the debounce interval would otherwise keep rescheduling the
+	// timer and starve the render, leaving the tree frozen for the whole scan. Once updates have been
+	// pending longer than TREE_RENDER_MAX_WAIT_MS, render immediately instead of deferring again.
+	private void scheduleTreeRender() {
+		Display display = Display.getDefault();
+		if (display == null || display.isDisposed()) {
+			return;
+		}
+		long now = System.currentTimeMillis();
+		if (firstPendingSince == 0) {
+			firstPendingSince = now;
+		}
+		if (now - firstPendingSince >= TREE_RENDER_MAX_WAIT_MS) {
+			display.timerExec(-1, treeRenderRunnable); // cancel any pending debounce
+			renderPendingTreeHtml();
+		} else {
+			display.timerExec(TREE_RENDER_DEBOUNCE_MS, treeRenderRunnable);
+		}
+	}
+
 	private void renderPendingTreeHtml() {
+		firstPendingSince = 0;
 		if (treeBrowserHandler == null) {
 			return;
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -22,7 +22,10 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Sash;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
+import org.eclipse.ui.themes.IThemeManager;
 
 import io.snyk.eclipse.plugin.html.BaseHtmlProvider;
 import io.snyk.eclipse.plugin.preferences.Preferences;
@@ -63,6 +66,8 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	// Wall-clock (ms) of the oldest tree update still waiting to render; 0 when nothing is pending.
 	// Only accessed on the UI thread (scheduleTreeRender / renderPendingTreeHtml).
 	private long firstPendingSince;
+	// Re-captures the themed background and re-renders when the user switches Eclipse light↔dark.
+	private IPropertyChangeListener themeChangeListener;
 
 	@Override
 	public void createPartControl(Composite parent) {
@@ -128,6 +133,38 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		// Re-read the background after the CSS engine has styled the view, then re-render so every panel
 		// matches the native Eclipse theme.
 		captureThemeBackgroundDeferred();
+
+		registerThemeChangeListener();
+	}
+
+	/**
+	 * Re-capture the themed background and re-render every panel when the workbench theme changes
+	 * (e.g. the user toggles light↔dark at runtime). Without this the captured background and the
+	 * cached foreground colors would keep the old theme's values until the view is recreated.
+	 */
+	private void registerThemeChangeListener() {
+		IThemeManager themeManager = PlatformUI.getWorkbench().getThemeManager();
+		themeChangeListener = event -> {
+			if (IThemeManager.CHANGE_CURRENT_THEME.equals(event.getProperty())) {
+				onThemeChanged();
+			}
+		};
+		themeManager.addPropertyChangeListener(themeChangeListener);
+	}
+
+	private void onThemeChanged() {
+		// Drop cached theme colors so panels re-resolve foreground/border/etc. (not just the
+		// background), then re-read the now-restyled background and re-render every panel. force=true
+		// because a theme change can alter foreground/accent colors while leaving the view background
+		// hex unchanged — the hex-equality gate below would otherwise skip the re-render.
+		BaseHtmlProvider.invalidateThemeCaches();
+		if (rootComposite == null || rootComposite.isDisposed()) {
+			return;
+		}
+		// Single deferred pass only: the e4 CSS engine restyles the view asynchronously, so an immediate
+		// render would read the pre-restyle background and then need a second correcting render (a double
+		// flash). One 300ms-deferred forced render picks up the restyled colors in a single pass.
+		rootComposite.getDisplay().timerExec(300, () -> applyThemeColors(true));
 	}
 
 	/**
@@ -146,6 +183,16 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	}
 
 	private void applyThemeColorsIfChanged() {
+		applyThemeColors(false);
+	}
+
+	/**
+	 * Re-applies the themed background to the panels and sashes. When {@code force} is false the panel
+	 * re-render is skipped if the background hex is unchanged (the startup/resize path). When true the
+	 * re-render always runs — used on a theme change, where foreground colors may have changed even if
+	 * the background hex did not.
+	 */
+	private void applyThemeColors(boolean force) {
 		if (rootComposite == null || rootComposite.isDisposed()) {
 			return;
 		}
@@ -159,7 +206,7 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		// the background color itself is unchanged.
 		applySashColor(themed);
 
-		if (hex.equals(BaseHtmlProvider.getIdeBackgroundColorHex())) {
+		if (!force && hex.equals(BaseHtmlProvider.getIdeBackgroundColorHex())) {
 			return;
 		}
 		BaseHtmlProvider.setIdeBackgroundColorHex(hex);
@@ -272,6 +319,9 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 
 	@Override
 	public void dispose() {
+		if (themeChangeListener != null) {
+			PlatformUI.getWorkbench().getThemeManager().removePropertyChangeListener(themeChangeListener);
+		}
 		if (sashColor != null && !sashColor.isDisposed()) {
 			sashColor.dispose();
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -60,12 +60,13 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	private volatile TreeViewBrowserHandler treeBrowserHandler;
 	private final AtomicReference<String> pendingHtml = new AtomicReference<>();
 	private static final int TREE_RENDER_DEBOUNCE_MS = 150;
-	private static final int TREE_RENDER_MAX_WAIT_MS = 600;
+	private static final long TREE_RENDER_MAX_WAIT_NANOS = 600L * 1_000_000L;
 	private static final String SASH_PAINTER_KEY = "snyk.sashPainter";
 	private final Runnable treeRenderRunnable = this::renderPendingTreeHtml;
-	// Wall-clock (ms) of the oldest tree update still waiting to render; 0 when nothing is pending.
-	// Only accessed on the UI thread (scheduleTreeRender / renderPendingTreeHtml).
-	private long firstPendingSince;
+	// System.nanoTime() of the oldest tree update still waiting to render (monotonic; valid only while
+	// treeRenderPending). Only accessed on the UI thread (scheduleTreeRender / renderPendingTreeHtml).
+	private long firstPendingSinceNanos;
+	private boolean treeRenderPending;
 	// Re-captures the themed background and re-renders when the user switches Eclipse light↔dark.
 	private IPropertyChangeListener themeChangeListener;
 
@@ -317,11 +318,20 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	@Override
 	public void dispose() {
 		if (themeChangeListener != null) {
-			PlatformUI.getWorkbench().getThemeManager().removePropertyChangeListener(themeChangeListener);
+			try {
+				PlatformUI.getWorkbench().getThemeManager().removePropertyChangeListener(themeChangeListener);
+			} catch (IllegalStateException e) {
+				// Workbench is already shutting down — there is nothing left to deregister from. Swallow
+				// so this cannot abort dispose() before the sashColor/static cleanup below.
+				SnykLogger.logInfo("Workbench unavailable while removing theme listener: " + e.getMessage());
+			}
 		}
 		if (sashColor != null && !sashColor.isDisposed()) {
 			sashColor.dispose();
 		}
+		// Clear the shared static background so it does not leak past this view's lifetime (a reopened
+		// view re-captures it in createPartControl; getIdeBackgroundHex falls back until then).
+		BaseHtmlProvider.setIdeBackgroundColorHex(null);
 		super.dispose();
 	}
 
@@ -431,11 +441,12 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		if (display == null || display.isDisposed()) {
 			return;
 		}
-		long now = System.currentTimeMillis();
-		if (firstPendingSince == 0) {
-			firstPendingSince = now;
+		long now = System.nanoTime();
+		if (!treeRenderPending) {
+			treeRenderPending = true;
+			firstPendingSinceNanos = now;
 		}
-		if (now - firstPendingSince >= TREE_RENDER_MAX_WAIT_MS) {
+		if (now - firstPendingSinceNanos >= TREE_RENDER_MAX_WAIT_NANOS) {
 			display.timerExec(-1, treeRenderRunnable); // cancel any pending debounce
 			renderPendingTreeHtml();
 		} else {
@@ -444,7 +455,7 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	}
 
 	private void renderPendingTreeHtml() {
-		firstPendingSince = 0;
+		treeRenderPending = false;
 		if (treeBrowserHandler == null) {
 			return;
 		}

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -153,18 +153,15 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	}
 
 	private void onThemeChanged() {
-		// Drop cached theme colors so panels re-resolve foreground/border/etc. (not just the
-		// background), then re-read the now-restyled background and re-render every panel. force=true
-		// because a theme change can alter foreground/accent colors while leaving the view background
-		// hex unchanged — the hex-equality gate below would otherwise skip the re-render.
-		BaseHtmlProvider.invalidateThemeCaches();
 		if (rootComposite == null || rootComposite.isDisposed()) {
 			return;
 		}
-		// Single deferred pass only: the e4 CSS engine restyles the view asynchronously, so an immediate
-		// render would read the pre-restyle background and then need a second correcting render (a double
-		// flash). One 300ms-deferred forced render picks up the restyled colors in a single pass.
-		rootComposite.getDisplay().timerExec(300, () -> applyThemeColors(true));
+		// Flip foreground and background together, in a single deferred pass. The 300ms delay lets the
+        // renderer restyle and redraw the view first.
+		rootComposite.getDisplay().timerExec(300, () -> {
+			BaseHtmlProvider.invalidateThemeCaches();
+			applyThemeColors(true);
+		});
 	}
 
 	/**

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -435,7 +435,7 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	// Debounce tree reloads to reduce flicker during a scan, but with a max-wait ceiling: a sustained
 	// burst of updates arriving faster than the debounce interval would otherwise keep rescheduling the
 	// timer and starve the render, leaving the tree frozen for the whole scan. Once updates have been
-	// pending longer than TREE_RENDER_MAX_WAIT_MS, render immediately instead of deferring again.
+	// pending longer than TREE_RENDER_MAX_WAIT_NANOS, render immediately instead of deferring again.
 	private void scheduleTreeRender() {
 		Display display = Display.getDefault();
 		if (display == null || display.isDisposed()) {
@@ -446,8 +446,11 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 			treeRenderPending = true;
 			firstPendingSinceNanos = now;
 		}
+		// Cancel any pending debounce first so rapid calls reschedule a single timer rather than stacking
+		// N of them (timerExec adds per call; it does not implicitly replace). The extras would be no-ops
+		// (getAndSet(null)), but coalescing avoids the redundant callbacks.
+		display.timerExec(-1, treeRenderRunnable);
 		if (now - firstPendingSinceNanos >= TREE_RENDER_MAX_WAIT_NANOS) {
-			display.timerExec(-1, treeRenderRunnable); // cancel any pending debounce
 			renderPendingTreeHtml();
 		} else {
 			display.timerExec(TREE_RENDER_DEBOUNCE_MS, treeRenderRunnable);

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SnykToolView.java
@@ -12,9 +12,16 @@ import org.eclipse.swt.SWTError;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.ControlListener;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Sash;
 import org.eclipse.ui.part.ViewPart;
 
 import io.snyk.eclipse.plugin.html.BaseHtmlProvider;
@@ -32,6 +39,16 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	 */
 	public static final String ID = "io.snyk.eclipse.plugin.views.snyktoolview";
 
+	private Composite rootComposite;
+	private SashForm horizontalSashForm;
+	private SashForm verticalSashForm;
+	// Panel-colored wrappers that host each browser (see createPartControl).
+	private Composite summaryPane;
+	private Composite treePane;
+	private Composite detailPane;
+	// Owned divider color for the sashes (a contrasting shade of the panel background). Disposed with
+	// the view; recreated whenever the panel background changes.
+	private Color sashColor;
 	private Browser browser;
 	private BrowserHandler browserHandler;
 	private Browser summaryBrowser;
@@ -39,20 +56,45 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 	private Browser treeBrowser;
 	private volatile TreeViewBrowserHandler treeBrowserHandler;
 	private final AtomicReference<String> pendingHtml = new AtomicReference<>();
+	private static final int TREE_RENDER_DEBOUNCE_MS = 150;
+	private static final String SASH_PAINTER_KEY = "snyk.sashPainter";
+	private final Runnable treeRenderRunnable = this::renderPendingTreeHtml;
 
 	@Override
 	public void createPartControl(Composite parent) {
-		SashForm horizontalSashForm = new SashForm(parent, SWT.HORIZONTAL);
+		this.rootComposite = parent;
+
+		// Best-effort background so the first render is not white. The e4 CSS engine styles the parent
+		// (to the same grey as native trees/views) only after createPartControl returns, so this initial
+		// read may be pre-theme; captureThemeBackgroundDeferred() below re-reads once styling is applied.
+		Color viewBackground = parent.getBackground();
+		BaseHtmlProvider.setIdeBackgroundColorHex(toHex(viewBackground));
+
+		applyBackground(parent, viewBackground);
+
+		horizontalSashForm = new SashForm(parent, SWT.HORIZONTAL);
 		horizontalSashForm.setLayout(new FillLayout());
 
-		SashForm verticalSashForm = new SashForm(horizontalSashForm, SWT.VERTICAL);
+		verticalSashForm = new SashForm(horizontalSashForm, SWT.VERTICAL);
 		verticalSashForm.setLayout(new FillLayout());
 
-		summaryBrowser = new Browser(verticalSashForm, SWT.EDGE);
+		// Sashes get a contrasting shade so the dividers between panels stay visible.
+		applySashColor(viewBackground);
+
+		// Each browser sits in a panel-colored wrapper. While a browser is hidden during a reload, the
+		// wrapper shows through in the panel color instead of the browser's opaque-white default — so a
+		// refresh reads as a brief dark (invisible in dark mode) transition rather than a white flash.
+		summaryPane = wrapperComposite(verticalSashForm, viewBackground);
+		summaryBrowser = new Browser(summaryPane, SWT.EDGE);
+		applyBackground(summaryBrowser, viewBackground);
+		summaryBrowser.setVisible(false);
 		summaryBrowserHandler = new SummaryBrowserHandler(summaryBrowser);
 		summaryBrowserHandler.initialize();
 
-		treeBrowser = new Browser(verticalSashForm, SWT.EDGE);
+		treePane = wrapperComposite(verticalSashForm, viewBackground);
+		treeBrowser = new Browser(treePane, SWT.EDGE);
+		applyBackground(treeBrowser, viewBackground);
+		treeBrowser.setVisible(false);
 		treeBrowserHandler = new TreeViewBrowserHandler(treeBrowser);
 		treeBrowserHandler.initialize();
 		String buffered = pendingHtml.getAndSet(null);
@@ -62,11 +104,171 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 
 		verticalSashForm.setWeights(1, 3);
 
-		browser = new Browser(horizontalSashForm, SWT.EDGE);
+		detailPane = wrapperComposite(horizontalSashForm, viewBackground);
+		browser = new Browser(detailPane, SWT.EDGE);
+		applyBackground(browser, viewBackground);
+		browser.setVisible(false);
 		browserHandler = new BrowserHandler(browser);
 		browserHandler.initialize();
 
 		horizontalSashForm.setWeights(1, 2);
+
+		// Re-assert the sash color on resize: the theme's CSS can repaint the Sash controls the panel
+		// color again (e.g. on a reskin), and resize is the point at which that would become visible.
+		ControlListener sashRecolor = ControlListener.controlResizedAdapter(e -> {
+			colorSashes(horizontalSashForm, sashColor);
+			colorSashes(verticalSashForm, sashColor);
+		});
+		horizontalSashForm.addControlListener(sashRecolor);
+		verticalSashForm.addControlListener(sashRecolor);
+
+		// Re-read the background after the CSS engine has styled the view, then re-render so every panel
+		// matches the native Eclipse grey (e.g. #2F2F2F in the dark theme).
+		captureThemeBackgroundDeferred();
+	}
+
+	/**
+	 * The e4 CSS engine applies theme styles (including the view background that matches native trees)
+	 * on a UI cycle after createPartControl. Re-read the parent background then and, if it changed,
+	 * re-publish it and re-render each panel so they adopt the correct grey. Attempted twice to guard
+	 * against the CSS styling landing a cycle later than the first attempt; the work is idempotent, so
+	 * the second attempt is a no-op once the color has been applied.
+	 */
+	private void captureThemeBackgroundDeferred() {
+		if (rootComposite == null || rootComposite.isDisposed()) {
+			return;
+		}
+		rootComposite.getDisplay().asyncExec(this::applyThemeColorsIfChanged);
+		rootComposite.getDisplay().timerExec(300, this::applyThemeColorsIfChanged);
+	}
+
+	private void applyThemeColorsIfChanged() {
+		if (rootComposite == null || rootComposite.isDisposed()) {
+			return;
+		}
+		Color themed = rootComposite.getBackground();
+		String hex = toHex(themed);
+		if (hex == null) {
+			return;
+		}
+		// Always (re)color the sashes: the Sash child controls do not exist yet at createPartControl time,
+		// and the theme's CSS may have repainted them the panel color since, so this must run even when
+		// the background color itself is unchanged.
+		applySashColor(themed);
+
+		if (hex.equals(BaseHtmlProvider.getIdeBackgroundColorHex())) {
+			return;
+		}
+		BaseHtmlProvider.setIdeBackgroundColorHex(hex);
+		applyBackground(rootComposite, themed);
+		applyBackground(summaryPane, themed);
+		applyBackground(treePane, themed);
+		applyBackground(detailPane, themed);
+		applyBackground(summaryBrowser, themed);
+		applyBackground(treeBrowser, themed);
+		applyBackground(browser, themed);
+		if (summaryBrowserHandler != null) {
+			summaryBrowserHandler.refreshTheme();
+		}
+		if (treeBrowserHandler != null) {
+			treeBrowserHandler.refreshTheme();
+		}
+		if (browserHandler != null) {
+			browserHandler.refreshTheme();
+		}
+	}
+
+	private Composite wrapperComposite(Composite parent, Color background) {
+		Composite wrapper = new Composite(parent, SWT.NONE);
+		wrapper.setLayout(new FillLayout());
+		applyBackground(wrapper, background);
+		return wrapper;
+	}
+
+	private String toHex(Color color) {
+		if (color == null) {
+			return null;
+		}
+		RGB rgb = color.getRGB();
+		return String.format("#%02x%02x%02x", rgb.red, rgb.green, rgb.blue);
+	}
+
+	// Set the native widget background so the area shown before/while HTML loads (and the gaps around
+	// the browsers) matches the theme instead of flashing white — jarring in dark mode.
+	private void applyBackground(Control control, Color background) {
+		if (control != null && !control.isDisposed() && background != null) {
+			control.setBackground(background);
+		}
+	}
+
+	/**
+	 * Paints the SashForm dividers a contrasting shade of the panel background so they stay visible
+	 * (setting them to the panel color made them disappear). Owns the created Color and disposes the
+	 * previous one.
+	 */
+	private void applySashColor(Color panelBackground) {
+		if (panelBackground == null || rootComposite == null || rootComposite.isDisposed()) {
+			return;
+		}
+		Color previous = sashColor;
+		sashColor = createDividerColor(rootComposite.getDisplay(), panelBackground);
+		applyBackground(horizontalSashForm, sashColor);
+		applyBackground(verticalSashForm, sashColor);
+		// Also color the Sash child controls directly: the theme's `.MPart Sash` CSS rule paints them the
+		// panel color (making them invisible), overriding the SashForm composite background set above.
+		colorSashes(horizontalSashForm, sashColor);
+		colorSashes(verticalSashForm, sashColor);
+		if (previous != null && !previous.isDisposed()) {
+			previous.dispose();
+		}
+	}
+
+	private void colorSashes(SashForm form, Color color) {
+		if (form == null || form.isDisposed()) {
+			return;
+		}
+		for (Control child : form.getChildren()) {
+			if (child instanceof Sash) {
+				child.setBackground(color);
+				// The theme's CSS repaints the Sash the panel color, and a plain setBackground does not
+				// survive its paint timing (the divider only appeared after the user interacted with it).
+				// Install a PaintListener that draws the divider color on top on every paint — this fires
+				// on the natural first paint when the view opens, so no interaction is needed.
+				if (child.getData(SASH_PAINTER_KEY) == null) {
+					child.setData(SASH_PAINTER_KEY, Boolean.TRUE);
+					child.addPaintListener(this::paintSash);
+				}
+				child.redraw();
+			}
+		}
+	}
+
+	private void paintSash(PaintEvent event) {
+		if (sashColor == null || sashColor.isDisposed() || !(event.widget instanceof Control)) {
+			return;
+		}
+		Point size = ((Control) event.widget).getSize();
+		event.gc.setBackground(sashColor);
+		event.gc.fillRectangle(0, 0, size.x, size.y);
+	}
+
+	/** Lightens a dark background / darkens a light one by a fixed step to yield a visible divider. */
+	private Color createDividerColor(Display display, Color background) {
+		RGB rgb = background.getRGB();
+		double luminance = (0.299 * rgb.red + 0.587 * rgb.green + 0.114 * rgb.blue) / 255.0;
+		int step = luminance < 0.5 ? 32 : -28;
+		int r = Math.min(255, Math.max(0, rgb.red + step));
+		int g = Math.min(255, Math.max(0, rgb.green + step));
+		int b = Math.min(255, Math.max(0, rgb.blue + step));
+		return new Color(display, r, g, b);
+	}
+
+	@Override
+	public void dispose() {
+		if (sashColor != null && !sashColor.isDisposed()) {
+			sashColor.dispose();
+		}
+		super.dispose();
 	}
 
 	@Override
@@ -159,16 +361,23 @@ public class SnykToolView extends ViewPart implements ISnykToolView {
 		try {
 			Display display = Display.getDefault();
 			if (display != null && !display.isDisposed()) {
-				display.asyncExec(() -> {
-					if (treeBrowserHandler == null) return;
-					String buffered = pendingHtml.getAndSet(null);
-					if (buffered != null) {
-						treeBrowserHandler.setBrowserText(buffered);
-					}
-				});
+				// Debounce: the LS pushes many tree-HTML updates during a scan and each reload flashes the
+				// browser. Rescheduling the same runnable coalesces a burst into a single render once the
+				// updates settle. timerExec must run on the UI thread, hence the asyncExec hop.
+				display.asyncExec(() -> display.timerExec(TREE_RENDER_DEBOUNCE_MS, treeRenderRunnable));
 			}
 		} catch (SWTError | SWTException | UnsatisfiedLinkError | NoClassDefFoundError e) {
 			SnykLogger.logInfo("No SWT Display available, HTML will be drained on createPartControl: " + e.getMessage());
+		}
+	}
+
+	private void renderPendingTreeHtml() {
+		if (treeBrowserHandler == null) {
+			return;
+		}
+		String buffered = pendingHtml.getAndSet(null);
+		if (buffered != null) {
+			treeBrowserHandler.setBrowserText(buffered);
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
@@ -11,9 +11,11 @@ import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
 public class SummaryBrowserHandler {
 	private Browser browser;
-	// Last summary rendered (null => the default init page). Kept so the panel can be re-rendered
-	// when the resolved theme color changes after the CSS engine has styled the view.
+	// Track the latest rendered summary so the panel can be re-rendered if the theme color
+    // changes when the CSS engine styles the view. hasSummary is false while only the default
+    // init page has been shown (avoids a null assignment, which the PMD ruleset rejects).
 	private String lastSummary;
+	private boolean hasSummary;
 
 	public SummaryBrowserHandler(Browser browser) {
 		this.browser = browser;
@@ -42,12 +44,13 @@ public class SummaryBrowserHandler {
 	}
 
 	public void setDefaultBrowserText() {
-		lastSummary = null;
+		hasSummary = false;
 		BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getSummaryInitHtml());
 	}
 
 	public void setBrowserText(String summary) {
 		lastSummary = summary;
+		hasSummary = true;
 		BrowserFlashGuard.setTextFlashSafe(browser,
 				StaticPageHtmlProvider.getInstance().getFormattedSummaryHtml(summary));
 	}
@@ -57,10 +60,10 @@ public class SummaryBrowserHandler {
 		if (browser == null || browser.isDisposed()) {
 			return;
 		}
-		if (lastSummary == null) {
-			setDefaultBrowserText();
-		} else {
+		if (hasSummary) {
 			setBrowserText(lastSummary);
+		} else {
+			setDefaultBrowserText();
 		}
 	}
 

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
@@ -11,6 +11,9 @@ import io.snyk.languageserver.protocolextension.SnykExtendedLanguageClient;
 
 public class SummaryBrowserHandler {
 	private Browser browser;
+	// Last summary rendered (null => the default init page). Kept so the panel can be re-rendered
+	// when the resolved theme color changes after the CSS engine has styled the view.
+	private String lastSummary;
 
 	public SummaryBrowserHandler(Browser browser) {
 		this.browser = browser;
@@ -34,15 +37,31 @@ public class SummaryBrowserHandler {
 			}
 		};
 
+		BrowserFlashGuard.install(browser);
 		setDefaultBrowserText();
 	}
 
 	public void setDefaultBrowserText() {
-		browser.setText(StaticPageHtmlProvider.getInstance().getSummaryInitHtml());
+		lastSummary = null;
+		BrowserFlashGuard.setTextFlashSafe(browser, StaticPageHtmlProvider.getInstance().getSummaryInitHtml());
 	}
 
 	public void setBrowserText(String summary) {
-		browser.setText(StaticPageHtmlProvider.getInstance().getFormattedSummaryHtml(summary));
+		lastSummary = summary;
+		BrowserFlashGuard.setTextFlashSafe(browser,
+				StaticPageHtmlProvider.getInstance().getFormattedSummaryHtml(summary));
+	}
+
+	/** Re-renders the current summary so it adopts a newly-resolved theme color. */
+	public void refreshTheme() {
+		if (browser == null || browser.isDisposed()) {
+			return;
+		}
+		if (lastSummary == null) {
+			setDefaultBrowserText();
+		} else {
+			setBrowserText(lastSummary);
+		}
 	}
 
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandler.java
@@ -1,5 +1,6 @@
 package io.snyk.eclipse.plugin.views.snyktoolview;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.swt.browser.Browser;
@@ -49,10 +50,12 @@ public class SummaryBrowserHandler {
 	}
 
 	public void setBrowserText(String summary) {
-		lastSummary = summary;
-		hasSummary = true;
-		BrowserFlashGuard.setTextFlashSafe(browser,
-				StaticPageHtmlProvider.getInstance().getFormattedSummaryHtml(summary));
+		// The LS re-pushes the summary frequently during a scan, often unchanged; skip those so the panel
+		// does not blink (hide → reveal) on every push. Mirrors the tree handler's dedup guard.
+		if (hasSummary && Objects.equals(summary, lastSummary)) {
+			return;
+		}
+		renderSummary(summary);
 	}
 
 	/** Re-renders the current summary so it adopts a newly-resolved theme color. */
@@ -61,10 +64,21 @@ public class SummaryBrowserHandler {
 			return;
 		}
 		if (hasSummary) {
-			setBrowserText(lastSummary);
+			// Go through renderSummary directly so the unchanged-content guard is bypassed — the text is
+			// the same but the resolved theme colors have changed.
+			renderSummary(lastSummary);
 		} else {
 			setDefaultBrowserText();
 		}
+	}
+
+	// Package-private (not private) so SummaryBrowserHandlerTest can override it to count renders and
+	// verify the setBrowserText dedup guard without a live SWT Browser.
+	void renderSummary(String summary) {
+		lastSummary = summary;
+		hasSummary = true;
+		BrowserFlashGuard.setTextFlashSafe(browser,
+				StaticPageHtmlProvider.getInstance().getFormattedSummaryHtml(summary));
 	}
 
 }

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/TreeViewBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/TreeViewBrowserHandler.java
@@ -4,20 +4,13 @@ import org.eclipse.swt.browser.Browser;
 
 import io.snyk.eclipse.plugin.html.BaseHtmlProvider;
 import io.snyk.eclipse.plugin.html.ExecuteCommandBridge;
+import io.snyk.eclipse.plugin.html.TreeViewHtmlProvider;
 
 public class TreeViewBrowserHandler {
 	private Browser browser;
-	// The feedback banner link (styles.css: .feedback-banner-link) uses --button-text-color, which the
-	// IDE resolves to the button foreground — black in the dark theme (readable on a light button, but
-	// not on the banner's dark gradient). Override it to the theme text color (white in dark, dark in
-	// light), matching the banner text. Injected via ${ideStyle}, which lands after the LS styles so it
-	// wins by cascade order.
-	private final BaseHtmlProvider htmlProvider = new BaseHtmlProvider() {
-		@Override
-		public String getCss() {
-			return ".feedback-banner-link { color: var(--text-color); }";
-		}
-	};
+	// Tree-specific provider: adds the feedback-banner link color override on top of the base
+	// theme-variable substitution (see TreeViewHtmlProvider).
+	private final BaseHtmlProvider htmlProvider = new TreeViewHtmlProvider();
 	// Last raw HTML rendered. The LS re-pushes tree HTML on many events (often identical); each
 	// full-document reload causes a visible flash, so we skip setText when nothing changed.
 	private String lastRenderedHtml;
@@ -55,13 +48,13 @@ public class TreeViewBrowserHandler {
 		if (html.equals(lastRenderedHtml)) {
 			return;
 		}
-		lastRenderedHtml = html;
-		browser.setText(htmlProvider.replaceCssVariables(html));
+		render(html);
 	}
 
 	/**
-	 * Re-renders the current content so it picks up a newly-resolved theme color. Bypasses the
-	 * unchanged-HTML guard, since the raw HTML is identical but the resolved colors have changed.
+	 * Re-renders the current content so it picks up a newly-resolved theme color. Goes through
+	 * {@link #render} directly (not {@link #setBrowserText}) so the unchanged-HTML guard is bypassed —
+	 * the raw HTML is identical but the resolved colors have changed.
 	 */
 	public void refreshTheme() {
 		if (browser == null || browser.isDisposed()) {
@@ -71,9 +64,12 @@ public class TreeViewBrowserHandler {
 			setEmptyPage();
 			return;
 		}
-		String html = lastRenderedHtml;
-		lastRenderedHtml = null;
-		setBrowserText(html);
+		render(lastRenderedHtml);
+	}
+
+	private void render(String html) {
+		lastRenderedHtml = html;
+		browser.setText(htmlProvider.replaceCssVariables(html));
 	}
 
 	public void selectNode(String issueId) {

--- a/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/TreeViewBrowserHandler.java
+++ b/plugin/src/main/java/io/snyk/eclipse/plugin/views/snyktoolview/TreeViewBrowserHandler.java
@@ -7,7 +7,20 @@ import io.snyk.eclipse.plugin.html.ExecuteCommandBridge;
 
 public class TreeViewBrowserHandler {
 	private Browser browser;
-	private final BaseHtmlProvider htmlProvider = new BaseHtmlProvider();
+	// The feedback banner link (styles.css: .feedback-banner-link) uses --button-text-color, which the
+	// IDE resolves to the button foreground — black in the dark theme (readable on a light button, but
+	// not on the banner's dark gradient). Override it to the theme text color (white in dark, dark in
+	// light), matching the banner text. Injected via ${ideStyle}, which lands after the LS styles so it
+	// wins by cascade order.
+	private final BaseHtmlProvider htmlProvider = new BaseHtmlProvider() {
+		@Override
+		public String getCss() {
+			return ".feedback-banner-link { color: var(--text-color); }";
+		}
+	};
+	// Last raw HTML rendered. The LS re-pushes tree HTML on many events (often identical); each
+	// full-document reload causes a visible flash, so we skip setText when nothing changed.
+	private String lastRenderedHtml;
 
 	public TreeViewBrowserHandler(Browser browser) {
 		this.browser = browser;
@@ -15,7 +28,21 @@ public class TreeViewBrowserHandler {
 
 	public void initialize() {
 		ExecuteCommandBridge.install(browser);
-		browser.setText("<html><body></body></html>");
+		// The tree must stay clickable while it refreshes during a scan, so it is NOT hidden on each
+		// reload (that would swallow clicks). It is hidden only for the cold-open load (by the view) and
+		// revealed once the first document finishes, with a safety reveal in case that event never fires.
+		BrowserFlashGuard.install(browser);
+		BrowserFlashGuard.scheduleSafetyReveal(browser);
+		setEmptyPage();
+	}
+
+	// Theme the empty placeholder page so it does not flash white before the tree HTML arrives.
+	private void setEmptyPage() {
+		if (browser == null || browser.isDisposed()) {
+			return;
+		}
+		browser.setText(htmlProvider.replaceCssVariables(
+				"<html><body style=\"background-color: var(--background-color)\"></body></html>"));
 	}
 
 	public void setBrowserText(String html) {
@@ -25,7 +52,28 @@ public class TreeViewBrowserHandler {
 		if (html == null) {
 			return;
 		}
+		if (html.equals(lastRenderedHtml)) {
+			return;
+		}
+		lastRenderedHtml = html;
 		browser.setText(htmlProvider.replaceCssVariables(html));
+	}
+
+	/**
+	 * Re-renders the current content so it picks up a newly-resolved theme color. Bypasses the
+	 * unchanged-HTML guard, since the raw HTML is identical but the resolved colors have changed.
+	 */
+	public void refreshTheme() {
+		if (browser == null || browser.isDisposed()) {
+			return;
+		}
+		if (lastRenderedHtml == null) {
+			setEmptyPage();
+			return;
+		}
+		String html = lastRenderedHtml;
+		lastRenderedHtml = null;
+		setBrowserText(html);
 	}
 
 	public void selectNode(String issueId) {

--- a/tests/src/test/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProviderTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/html/TreeViewHtmlProviderTest.java
@@ -1,0 +1,56 @@
+package io.snyk.eclipse.plugin.html;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.snyk.eclipse.plugin.preferences.InMemoryPreferenceStore;
+import io.snyk.eclipse.plugin.preferences.InMemorySecurePreferenceStore;
+import io.snyk.eclipse.plugin.preferences.Preferences;
+
+class TreeViewHtmlProviderTest {
+
+	@BeforeEach
+	void setUp() {
+		// Test mode makes getColorAsHex return "" so replaceCssVariables resolves without a workbench.
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(), new InMemorySecurePreferenceStore());
+		prefs.setTest(true);
+	}
+
+	@Test
+	void getCss_overridesFeedbackBannerLinkColor() {
+		TreeViewHtmlProvider provider = new TreeViewHtmlProvider();
+
+		assertTrue(provider.getCss().contains(".feedback-banner-link"),
+				"tree provider must override the feedback-banner link color");
+	}
+
+	// The override reaches the rendered HTML only if it has an ${ideStyle} injection point. This locks in
+	// the plugin-side contract so a getCss()/injection regression is caught. (The live LS tree template
+	// contains ${ideStyle} — verified in snyk-ls treeview/template/tree.html — but that is served at
+	// runtime and cannot be asserted from a plugin unit test.)
+	@Test
+	void replaceCssVariables_injectsFeedbackBannerLinkRule_whenIdeStyleMarkerPresent() {
+		TreeViewHtmlProvider provider = new TreeViewHtmlProvider();
+		String html = "<html><head><style>{{.Styles}}</style>${ideStyle}</head><body></body></html>";
+
+		String result = provider.replaceCssVariables(html);
+
+		assertTrue(result.contains(".feedback-banner-link"),
+				"the getCss override must be injected at the ${ideStyle} marker");
+		assertFalse(result.contains("${ideStyle}"), "the ${ideStyle} marker must be consumed");
+	}
+
+	@Test
+	void replaceCssVariables_omitsRule_whenNoInjectionPoint() {
+		TreeViewHtmlProvider provider = new TreeViewHtmlProvider();
+		String html = "<html><head></head><body></body></html>";
+
+		String result = provider.replaceCssVariables(html);
+
+		assertFalse(result.contains(".feedback-banner-link"),
+				"without an ${ideStyle} injection point the override cannot appear");
+	}
+}

--- a/tests/src/test/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandlerTest.java
+++ b/tests/src/test/java/io/snyk/eclipse/plugin/views/snyktoolview/SummaryBrowserHandlerTest.java
@@ -1,0 +1,76 @@
+package io.snyk.eclipse.plugin.views.snyktoolview;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.snyk.eclipse.plugin.preferences.InMemoryPreferenceStore;
+import io.snyk.eclipse.plugin.preferences.InMemorySecurePreferenceStore;
+import io.snyk.eclipse.plugin.preferences.Preferences;
+
+class SummaryBrowserHandlerTest {
+
+	// Counts renderSummary invocations so the dedup guard is observable without a live SWT Browser.
+	// The browser is null; renderSummary's BrowserFlashGuard call is a no-op on a null browser, but the
+	// hasSummary/lastSummary bookkeeping (which the guard reads) still runs via super.
+	private static final class CountingSummaryBrowserHandler extends SummaryBrowserHandler {
+		int renders;
+
+		CountingSummaryBrowserHandler() {
+			super(null);
+		}
+
+		@Override
+		void renderSummary(String summary) {
+			renders++;
+			super.renderSummary(summary);
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		Preferences prefs = Preferences.getTestInstance(new InMemoryPreferenceStore(), new InMemorySecurePreferenceStore());
+		prefs.setTest(true);
+	}
+
+	@Test
+	void setBrowserText_rendersOnFirstCall() {
+		CountingSummaryBrowserHandler handler = new CountingSummaryBrowserHandler();
+
+		handler.setBrowserText("summary-a");
+
+		assertEquals(1, handler.renders, "first summary must render");
+	}
+
+	@Test
+	void setBrowserText_skipsIdenticalConsecutiveSummary() {
+		CountingSummaryBrowserHandler handler = new CountingSummaryBrowserHandler();
+
+		handler.setBrowserText("summary-a");
+		handler.setBrowserText("summary-a");
+
+		assertEquals(1, handler.renders, "an identical repeated summary must be deduped (not re-rendered)");
+	}
+
+	@Test
+	void setBrowserText_rendersWhenSummaryChanges() {
+		CountingSummaryBrowserHandler handler = new CountingSummaryBrowserHandler();
+
+		handler.setBrowserText("summary-a");
+		handler.setBrowserText("summary-b");
+
+		assertEquals(2, handler.renders, "a changed summary must render");
+	}
+
+	@Test
+	void setBrowserText_rendersAgainAfterDefaultReset() {
+		CountingSummaryBrowserHandler handler = new CountingSummaryBrowserHandler();
+
+		handler.setBrowserText("summary-a");
+		handler.setDefaultBrowserText(); // resets hasSummary
+		handler.setBrowserText("summary-a");
+
+		assertEquals(2, handler.renders, "after the default page reset, the same summary text must render again");
+	}
+}


### PR DESCRIPTION
### Description

Before:
<img width="1934" height="1172" alt="Screenshot 2026-07-08 at 17 17 07" src="https://github.com/user-attachments/assets/744b8d44-54bd-48b5-a7e5-63457149ec05" />

After:
<img width="2273" height="1538" alt="Screenshot 2026-07-09 at 09 42 15" src="https://github.com/user-attachments/assets/d2cc4e4f-24fe-48b0-af0c-108c9ac2a708" />

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
