### PR TITLE
chore: remove dead CHANGELOG references from PR template and RELEASE

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,6 @@ _Provide description of this PR and changes, if linked Jira ticket doesn't cover
 - [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
 - [ ] Tests added and all succeed
 - [ ] Linted
-- [ ] CHANGELOG.md updated
 - [ ] README.md updated, if user-facing
 
 ### Screenshots / GIFs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,12 +11,6 @@
   - Do not change values that do not represent the plugin version.
 
 
-**Update Changelog**
-
-- In the plugin/extension repo, make sure the the Changelog is updated with the correct version to be released and the correct changes in the release.
-  - Make sure Early Access are specified correctly for new feature.
-
-
 **Build Artifacts**
 
 - Use  `mvnw clean package`  or  `mvnw clean verify`  to build the project and ensure artifacts are created with the correct versions.


### PR DESCRIPTION
## Description

CHANGELOG.md is no longer hand-maintained: release workflows generate notes via `gh release create --generate-notes`. This removes the dead CHANGELOG references from the PR template and release docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)