### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+Snyk Eclipse plugin — a Maven/Tycho project (Eclipse plugin + feature + update
+site) that embeds the Snyk CLI/Language Server. See [README.md](README.md),
+[CONTRIBUTING.md](CONTRIBUTING.md) and `.cursorrules` for contributor guidance
+and coding standards. This file adds Cursor Cloud environment notes.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for agents running in the Cursor Cloud Linux VM.
+
+- **Build/test with JDK 17, not the default JDK 21.** The project targets Java 17
+  (CI uses Temurin 17) and the test suite mocks with Mockito's inline mock-maker.
+  Under the VM's default JDK 21 the tests fail with hundreds of
+  `MockitoException: Could not modify all classes [class java.lang.Object, …]`
+  (ByteBuddy self-attach). Compilation/packaging succeed on 21, but **tests need
+  JDK 17**. Point `JAVA_HOME` at a JDK 17 before building:
+  `export JAVA_HOME=/usr/lib/jvm/jdk-17.0.13+11; export PATH="$JAVA_HOME/bin:$PATH"`
+  (install a Temurin 17 if one is not present, e.g. from the
+  `adoptium/temurin17-binaries` GitHub release).
+- **Standard command:** `./mvnw clean verify -DtrimStackTrace=false` (the CI
+  command). The Maven wrapper fetches Maven from `repo.maven.apache.org`; the
+  Tycho target platform pulls p2 repos from `download.eclipse.org` /
+  `repo.eclipse.org`; and the LS-download tests fetch the Snyk CLI/LS binary from
+  Snyk's CDN — all reachable in the VM. A clean run compiles all bundles and runs
+  400 tests (0 failures/errors). Do **not** pass `-P sign` (needs signing certs).
+- **Reachable:** `repo.maven.apache.org`, `download.eclipse.org`, `repo.eclipse.org`,
+  `static.snyk.io`, `downloads.snyk.io`, `github.com`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an `AGENTS.md` (the repo had no agent file, only `.cursorrules`) with a `## Cursor Cloud specific instructions` section for the Cursor Cloud Linux VM.

## Notes captured

- Build/test with **JDK 17**, not the VM's default JDK 21: under JDK 21 the Mockito inline mock-maker fails with hundreds of `Could not modify all classes [class java.lang.Object, …]` (ByteBuddy self-attach). Set `JAVA_HOME` to a Temurin 17 before building.
- Standard command: `./mvnw clean verify -DtrimStackTrace=false` (no `-P sign`). Target platform (`download.eclipse.org`/`repo.eclipse.org`), Maven central, and the Snyk CLI/LS CDN are all reachable in the VM.

## Verification

`./mvnw clean verify -DtrimStackTrace=false` with `JAVA_HOME` = JDK 17: BUILD SUCCESS, 400 tests, 0 failures/0 errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

