### PR TITLE
docs: note LS-up-before-Preferences timing gotcha in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,4 @@ Root `pom.xml` declares five Tycho modules, built in order:
 - Never push without asking first, and never force-push. Regularly fetch `main` and offer to merge it into the working branch.
 - After pushing, offer to open a draft PR using `.github/pull_request_template.md` (or update the existing PR description) with a title/description generated from the diff against `main`. Per `CONTRIBUTING.md`, a change applicable to the other Snyk IDE plugins (vscode-extension, snyk-intellij-plugin, snyk-visual-studio-plugin) should get matching PRs opened there too, since releases are usually coordinated.
 - Keep `./docs` up to date; document tested scenarios and add Mermaid diagrams for new flows.
+- Confirm the language server is actually up before touching Preferences — the trust controls do not render until it is. Check with: `pgrep -af 'snyk-(linux|macos|win) language-server'` (Windows without a POSIX shell: `tasklist | findstr snyk-win` or `Get-Process snyk-win`).


### PR DESCRIPTION
### Description

Adds a one-line note to AGENTS.md's Development Workflow section: the Preferences page's trust controls don't render until the Snyk language server is up, with a `pgrep` check to confirm the LS process is running before touching Preferences.

This consolidates guidance that was previously documented only on a shared cross-repo Confluence setup-instructions page as a generic tip. It's actually specific to this repo's own Eclipse Preferences UI, so it belongs in this repo's AGENTS.md instead of a shared doc.

The pgrep pattern was broadened during review to match all three platform LS binary names (`snyk-linux`/`snyk-macos`/`snyk-win.exe`, per `Platform.java`), with a Windows-native fallback (`tasklist`/`Get-Process`) — the originally proposed Linux-only pattern would silently report "not running" on macOS/Windows.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-eclipse-plugin/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed (N/A — docs-only change)
- [x] Linted (N/A — docs-only change)
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

N/A — docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or build impact.
> 
> **Overview**
> Adds a **Development Workflow** bullet in `AGENTS.md` warning that Eclipse **Preferences** trust controls only appear after the Snyk language server is running, and documents how to verify the LS process is up.
> 
> The check uses `pgrep` against `snyk-(linux|macos|win) language-server`, with Windows fallbacks (`tasklist` / `Get-Process snyk-win`) when POSIX shell tools aren’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df3fa940e2a6a7da1a77c04f8dc8834d1f039cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->