### PR TITLE
chore: bump version to 3.11.0 [IDE-2545]

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: bump-version
+description: Bump the snyk-eclipse-plugin release version across all files that carry it. Use when asked to bump/release the version, prepare a release, or when touching RELEASE.md. This skill may need updating if a Snyk Eclipse plugin version field is added or removed in a MANIFEST.MF, pom.xml, or category.xml.
+---
+
+## Before touching any file
+
+1. Read the current version from `pom.xml` (`<version>X.Y.Z-SNAPSHOT</version>`).
+2. Check whether a bump is even due, without needing a target version up front:
+   - `git fetch --tags origin`
+   - Find the latest release tag: `git describe --tags --abbrev=0 origin/main` (or `gh release list --limit 1`).
+   - Read that tag's `pom.xml` version: `git show <tag>:pom.xml | grep -m1 '<version>'`.
+   - Compare it to your local `pom.xml` version (`grep -m1 '<version>' pom.xml`).
+   - Same version on both → nothing has moved past the last release yet → a bump is due, proceed.
+   - Local already ahead of the tagged version → someone already bumped → stop and tell the user.
+
+## The version lives in 11 files, in two conventions
+
+Maven `pom.xml` files use `X.Y.Z-SNAPSHOT`:
+- `pom.xml`, `feature/pom.xml`, `plugin/pom.xml`, `target-platform/pom.xml`, `tests/pom.xml`, `update-site/pom.xml`
+
+OSGi/Eclipse files use `X.Y.Z.qualifier`:
+- `plugin/META-INF/MANIFEST.MF`, `tests/META-INF/MANIFEST.MF` (`Bundle-Version:` line)
+- `feature/feature.xml` (`version=` attribute)
+- `feature/category.xml`, `update-site/category.xml` (both the `version=` attribute and the jar filename in the `url=` attribute)
+
+Update both occurrences in `feature/category.xml` and `update-site/category.xml`. Don't touch `feature/feature.xml`'s `<plugin ... version="0.0.0">` entry — `0.0.0` is Tycho's auto-resolve placeholder, not a version literal.
+
+## Check whether the LS protocol version also needs bumping
+
+The plugin pins a required Language Server protocol version in `plugin/src/main/java/io/snyk/languageserver/download/LsBinaries.java` (`REQUIRED_LS_PROTOCOL_VERSION`). Compare it against snyk-ls's current release value:
+
+```
+git -C <path-to-snyk-ls-checkout> fetch origin main
+git -C <path-to-snyk-ls-checkout> show origin/main:.goreleaser.yaml | grep LS_PROTOCOL_VERSION
+```
+
+If they match, no action needed. If the plugin's pinned version is behind, flag it to the user and ask whether to bump `REQUIRED_LS_PROTOCOL_VERSION` as part of this release or leave it.
+
+## Decide the target version
+
+Every historical bump in this repo increments the minor digit and leaves patch at 0 (`X.Y.0` → `X.(Y+1).0`) — there is no precedent for a true patch-digit bump (`X.Y.Z` → `X.Y.(Z+1)`). If asked for a "patch" bump specifically, flag the mismatch with what history shows and ask which the user actually wants rather than assuming. They may actually want an emergency hotfix, but this isn't something that has been done before.
+
+## Make the change, then verify against precedent
+
+After editing, cross-check against 2-4 prior bump commits. Find them from `pom.xml`'s own history rather than trusting commit message wording (not every bump commit is worded the same way):
+
+- `git log --oneline -- pom.xml` — pick a few recent candidates.
+- `git show --stat <sha>` on each — a real version bump touches all 11 files listed above with one line changed each; skip anything else (dependency bumps, LS protocol bumps, changelog edits also touch `pom.xml` but look different).
+
+Confirm your own change matches that shape:
+- Same 11 files touched, nothing more, nothing fewer. Unless you did a LS protocol version bump as well.
+- `git diff --stat` shows `11 files changed, 11 insertions(+), 11 deletions(-)`. Unless you did a LS protocol version bump as well.
+
+If the file set or line count doesn't match, figure out why.
+
+## Commit
+
+Follow this repo's standard commit workflow — see `AGENTS.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -204,7 +204,8 @@ hs_err_pid*
 /update-site/.dcignore
 .dccache
 
-.claude
+.claude/*
+!.claude/skills/
 *IDE-*
 tests.json
 .vscode

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 
 - Update the release version in all files that specify the Eclipse plugin version.
   - Do not change values that do not represent the plugin version.
+  - Coding agents can use the `bump-version` skill (`.claude/skills/bump-version/SKILL.md`) to do this step, including the protocol version check above.
 
 
 **Update Changelog**

--- a/feature/category.xml
+++ b/feature/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_3.10.0.qualifier.jar" id="io.snyk.scanner" version="3.10.0.qualifier">
+  <feature url="features/io.snyk.scanner_3.11.0.qualifier.jar" id="io.snyk.scanner" version="3.11.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security">

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="io.snyk.scanner"
       label="Snyk Security"
-      version="3.10.0.qualifier"
+      version="3.11.0.qualifier"
       provider-name="Snyk">
 
    <description url="https://snyk.io">

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.snyk.scanner</artifactId>

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: io.snyk.eclipse.plugin;singleton:=true
-Bundle-Version: 3.10.0.qualifier
+Bundle-Version: 3.11.0.qualifier
 Bundle-Activator: io.snyk.eclipse.plugin.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.11.0-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.snyk</groupId>
     <artifactId>parent</artifactId>
-    <version>3.10.0-SNAPSHOT</version>
+    <version>3.11.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.11.0-SNAPSHOT</version>
     </parent>
     <packaging>eclipse-target-definition</packaging>
 </project>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: io.snyk.eclipse.plugin.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: io.snyk.eclipse.plugin.tests;singleton:=true
-Bundle-Version: 3.10.0.qualifier
+Bundle-Version: 3.11.0.qualifier
 Bundle-Vendor: Snyk
 Fragment-Host: io.snyk.eclipse.plugin
 Automatic-Module-Name: io.snyk

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.snyk.eclipse.plugin.tests</artifactId>

--- a/update-site/category.xml
+++ b/update-site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature url="features/io.snyk.scanner_3.10.0.qualifier.jar" id="io.snyk.scanner" version="3.10.0.qualifier">
+  <feature url="features/io.snyk.scanner_3.11.0.qualifier.jar" id="io.snyk.scanner" version="3.11.0.qualifier">
     <category name="io.snyk.scanner"/>
   </feature>
   <category-def name="io.snyk.scanner" label="Snyk Security">

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.snyk</groupId>
         <artifactId>parent</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.11.0-SNAPSHOT</version>
     </parent>
     <packaging>eclipse-repository</packaging>
     <build>


### PR DESCRIPTION
### Description

Mechanical version bump 3.10.0(-SNAPSHOT) -> 3.11.0(-SNAPSHOT) across the same 11 files touched by prior release commits (#440, #251). No code changes.

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

N/A — version-string only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and release-documentation changes only; no runtime or security-sensitive logic is modified.
> 
> **Overview**
> Prepares the **3.11.0** release by bumping **3.10.0 → 3.11.0** across the usual **11** version-bearing files: parent/module `pom.xml` (`*-SNAPSHOT`), OSGi `Bundle-Version`, `feature.xml`, and both `category.xml` feature `url`/`version` fields. No plugin Java or LS protocol pin changes.
> 
> Also adds a **`bump-version`** Claude skill (`.claude/skills/bump-version/SKILL.md`) that documents when a bump is due, which files to edit, LS protocol checks, and how to validate against prior bump commits. **`RELEASE.md`** now points release prep at that skill. **`.gitignore`** is adjusted so `.claude/*` stays ignored but **`.claude/skills/`** can be tracked in git.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bdc5213eb80fe5cef5563429b4eb3b38df9038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->