### PR TITLE
chore(ci): flip Remy to PR against main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
           open-source-agentic-fix-enabled: true
+          open-source-agentic-fix-base-branch: main
           open-source-scan-all-projects: true
           open-source-additional-arguments: --exclude=tests
           iac-scan: disabled


### PR DESCRIPTION
Adds `open-source-agentic-fix-base-branch: main` to `.circleci/config.yml`'s `prodsec/security_scans` step (prodsec-orb v1.2.32), so the agentic-fix bot targets `main` instead of whatever feature branch it happens to scan — same pattern that caused snyk/snyk-ls#1428 to land against a feature branch instead of `main` (background: [internal Slack thread](https://snyk.slack.com/archives/C0BN7BE23EV/p1788508444144189?thread_ts=1788452322.245549&cid=C0BN7BE23EV)).

Companion PRs: snyk/snyk-ls#1432, snyk/snyk-intellij-plugin#893, snyk/vscode-extension (pending).

Draft until CI runs and we see whether a real vulnerability on this branch actually gets fixed against `main` (see snyk/snyk-intellij-plugin#893 for a case where the scan found nothing to fix, so the change was untestable there).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only prodsec orb configuration with no application or runtime behavior changes.
> 
> **Overview**
> Configures CircleCI **prodsec/security_scans** so agentic vulnerability fixes open PRs against **`main`** instead of the branch under scan.
> 
> Adds `open-source-agentic-fix-base-branch: main` alongside the existing `open-source-agentic-fix-enabled: true` setting, matching the prodsec-orb pattern used to avoid fix PRs targeting feature branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c017e48d2d9bc62cc7c0b304606cca80a2ec5e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->