### PR TITLE
ci: add test-linux job to CircleCI CICD workflow [IDE-2497]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
           open-source-additional-arguments: --exclude=tests
           iac-scan: disabled
 
+  test-linux:
+    resource_class: medium
+    docker:
+      - image: cimg/openjdk:17.0
+    steps:
+      - checkout
+      - run:
+          name: Maven verify
+          command: ./mvnw clean verify -DtrimStackTrace=false
+
 workflows:
   version: 2
   CICD:
@@ -34,3 +44,5 @@ workflows:
           context:
             - devex_ide
             - prodsec-orb-runtime
+
+      - test-linux


### PR DESCRIPTION
### Description

Milestone 1 of the CircleCI migration for testing (IDE-2497). Adds a `test-linux` job to `.circleci/config.yml`, running `./mvnw clean verify -DtrimStackTrace=false` on `cimg/openjdk:17.0`, alongside the existing `security-scans`/`secrets-scan` jobs.

This mirrors GitHub Actions' non-main test leg only. It deliberately skips the `-P sign` release build GitHub Actions runs on `main` — this job runs in parallel as extra testing coverage, it does not replace GitHub Actions' sign/release/publish process (that's IDE-2483, kept out of scope here).

No signing, no S3 upload, no branch-protection changes, no GitHub Actions files touched or removed yet — this is deliberately the smallest slice, to be verified against a real CircleCI run before macOS/Windows legs (milestones 2-3) and eventual cutover (milestone 4) follow as separate stacked PRs.

Draft until CircleCI's `test-linux` job is observed green on this branch.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#457 test-linux ← YOU ARE HERE\nmilestone 1"]
    PR2["#458 test-macos\nmilestone 2"]
    PR3["#459 test-windows\nmilestone 3"]
    main --> PR1 --> PR2 --> PR3
    style PR1 fill:#ffd700,color:#000
```

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [ ] Tests added and all succeed — CircleCI run pending
- [x] Linted
- [ ] CHANGELOG.md updated — N/A, CI-only change
- [ ] README.md updated, if user-facing — N/A

### Screenshots / GIFs

N/A — CI config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition that runs existing Maven verify in parallel; no application, auth, or release pipeline changes.
> 
> **Overview**
> **Adds a Linux Maven test job to CircleCI** as the first step of IDE-2497’s migration from GitHub Actions for testing.
> 
> A new `test-linux` job uses `cimg/openjdk:17.0` (medium resource class) and runs `./mvnw clean verify -DtrimStackTrace=false`, wired into the existing `CICD` workflow alongside secrets and security scans. It mirrors the non–`-P sign` verify step from GitHub Actions and does not handle signing, release, or publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ca38bb2c5b995dfe7aa8e2a8dddc3c0e8cf68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->