### PR TITLE
ci: add test-macos job to CircleCI CICD workflow [IDE-2497]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,30 +39,8 @@ jobs:
       - run:
           name: Install Temurin JDK 17
           command: |
-            # Pinned to a specific Adoptium GA release: the /binary/latest endpoint used here
-            # previously can silently pick up a new patch release with no PR/diff to review.
-            JDK_RELEASE="jdk-17.0.20.1+1"
-            JDK_PLATFORM_PATH="mac/aarch64/jdk/hotspot/normal/eclipse"
-            JDK_URL="https://api.adoptium.net/v3/binary/version/${JDK_RELEASE}/${JDK_PLATFORM_PATH}"
-            JDK_CHECKSUM_URL="https://api.adoptium.net/v3/checksum/version/${JDK_RELEASE}/${JDK_PLATFORM_PATH}"
-            curl -fsSL -o /tmp/temurin17.tar.gz "$JDK_URL"
-            curl -fsSL -o /tmp/temurin17.tar.gz.sha256.txt "$JDK_CHECKSUM_URL"
-            EXPECTED_SHA=$(awk '{print $1}' /tmp/temurin17.tar.gz.sha256.txt)
-            if command -v sha256sum > /dev/null 2>&1; then
-              echo "${EXPECTED_SHA}  /tmp/temurin17.tar.gz" | sha256sum -c -
-            elif command -v shasum > /dev/null 2>&1; then
-              echo "${EXPECTED_SHA}  /tmp/temurin17.tar.gz" | shasum -a 256 -c -
-            else
-              echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
-              exit 1
-            fi
-            sudo mkdir -p /Library/Java/JavaVirtualMachines
-            sudo tar -xzf /tmp/temurin17.tar.gz -C /Library/Java/JavaVirtualMachines
-            JAVA_HOME_17="$(/usr/libexec/java_home -v 17)" || true
-            if [ -z "$JAVA_HOME_17" ]; then
-              echo "Temurin 17 was not found by /usr/libexec/java_home after extraction" >&2
-              exit 1
-            fi
+            brew install --cask --no-ask temurin@17
+            JAVA_HOME_17="$(/usr/libexec/java_home -v 17 --failfast)"
             echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
             echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,13 @@ jobs:
       xcode: 16.4.0
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Homebrew downloads cache
+          keys:
+            # Prefix-only match, restores whatever was most recently saved. Homebrew's own
+            # cleanup auto-removes cached downloads after 120 days, so each restored cache's
+            # content size stays bounded rather than growing unboundedly.
+            - brew-downloads-
       # Tycho/Mockito require JDK 17 specifically (JDK 21+ breaks Mockito's inline-mock
       # byte-buddy agent), and the JDK bundled with the Xcode image isn't guaranteed to be 17.
       - run:
@@ -43,6 +50,14 @@ jobs:
             JAVA_HOME_17="$(/usr/libexec/java_home -v 17 --failfast)"
             echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
             echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"
+      - save_cache:
+          name: Save Homebrew downloads cache
+          # CircleCI cache keys are immutable -- save_cache is a no-op if the exact key
+          # already has a saved cache. A static key would only ever persist the first
+          # run's content forever, so {{ epoch }} forces a brand-new key every run.
+          key: brew-downloads--{{ epoch }}
+          paths:
+            - ~/Library/Caches/Homebrew/downloads
       - restore_cache:
           name: Restore Maven/Tycho cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run:
           name: Install Temurin JDK 17
           command: |
-            brew install --cask temurin@17
+            HOMEBREW_NO_ASK=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask temurin@17
             JAVA_HOME_17="$(/usr/libexec/java_home -v 17 --failfast)"
             echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
             echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,18 @@ jobs:
             JAVA_HOME_17="$(/usr/libexec/java_home -v 17 --failfast)"
             echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
             echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"
+      - restore_cache:
+          name: Restore Maven/Tycho cache
+          keys:
+            - &m2-macos-cache-key m2-macos--pom.xml-{{ checksum "pom.xml" }}--plugin/pom.xml-{{ checksum "plugin/pom.xml" }}--tests/pom.xml-{{ checksum "tests/pom.xml" }}--target-platform/target-platform.target-{{ checksum "target-platform/target-platform.target" }}
       - run:
           name: Maven verify
           command: ./mvnw clean verify -DtrimStackTrace=false
+      - save_cache:
+          name: Save Maven/Tycho cache
+          key: *m2-macos-cache-key
+          paths:
+            - ~/.m2/repository
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,47 @@ jobs:
           name: Maven verify
           command: ./mvnw clean verify -DtrimStackTrace=false
 
+  test-macos:
+    resource_class: m4pro.medium
+    macos:
+      xcode: 16.4.0
+    steps:
+      - checkout
+      # Tycho/Mockito require JDK 17 specifically (JDK 21+ breaks Mockito's inline-mock
+      # byte-buddy agent), and the JDK bundled with the Xcode image isn't guaranteed to be 17.
+      - run:
+          name: Install Temurin JDK 17
+          command: |
+            # Pinned to a specific Adoptium GA release: the /binary/latest endpoint used here
+            # previously can silently pick up a new patch release with no PR/diff to review.
+            JDK_RELEASE="jdk-17.0.20.1+1"
+            JDK_PLATFORM_PATH="mac/aarch64/jdk/hotspot/normal/eclipse"
+            JDK_URL="https://api.adoptium.net/v3/binary/version/${JDK_RELEASE}/${JDK_PLATFORM_PATH}"
+            JDK_CHECKSUM_URL="https://api.adoptium.net/v3/checksum/version/${JDK_RELEASE}/${JDK_PLATFORM_PATH}"
+            curl -fsSL -o /tmp/temurin17.tar.gz "$JDK_URL"
+            curl -fsSL -o /tmp/temurin17.tar.gz.sha256.txt "$JDK_CHECKSUM_URL"
+            EXPECTED_SHA=$(awk '{print $1}' /tmp/temurin17.tar.gz.sha256.txt)
+            if command -v sha256sum > /dev/null 2>&1; then
+              echo "${EXPECTED_SHA}  /tmp/temurin17.tar.gz" | sha256sum -c -
+            elif command -v shasum > /dev/null 2>&1; then
+              echo "${EXPECTED_SHA}  /tmp/temurin17.tar.gz" | shasum -a 256 -c -
+            else
+              echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+              exit 1
+            fi
+            sudo mkdir -p /Library/Java/JavaVirtualMachines
+            sudo tar -xzf /tmp/temurin17.tar.gz -C /Library/Java/JavaVirtualMachines
+            JAVA_HOME_17="$(/usr/libexec/java_home -v 17)" || true
+            if [ -z "$JAVA_HOME_17" ]; then
+              echo "Temurin 17 was not found by /usr/libexec/java_home after extraction" >&2
+              exit 1
+            fi
+            echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
+            echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"
+      - run:
+          name: Maven verify
+          command: ./mvnw clean verify -DtrimStackTrace=false
+
 workflows:
   version: 2
   CICD:
@@ -46,3 +87,4 @@ workflows:
             - prodsec-orb-runtime
 
       - test-linux
+      - test-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run:
           name: Install Temurin JDK 17
           command: |
-            brew install --cask --no-ask temurin@17
+            brew install --cask temurin@17
             JAVA_HOME_17="$(/usr/libexec/java_home -v 17 --failfast)"
             echo "export JAVA_HOME=$JAVA_HOME_17" >> "$BASH_ENV"
             echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"


### PR DESCRIPTION
### Description

Milestone 2 of the CircleCI test migration (IDE-2497). Adds a `test-macos` job running the same `./mvnw clean verify -DtrimStackTrace=false` as `test-linux`, on a macOS executor (`xcode: 16.4.0`), installing Temurin JDK 17 via Homebrew (`brew install --cask temurin@17` with `HOMEBREW_NO_ASK=1 HOMEBREW_NO_AUTO_UPDATE=1`).

Isolated from `test-linux` on its own PR deliberately: a prior abandoned attempt (PR #449) broke on this exact macOS leg with an unverified checksum bug. This PR fixes that class of bug up front and is verified green against a real CircleCI run.

Milestone 1 (`test-linux`, PR #457) has merged into `main` — this PR's base is `main` directly now.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR2["#458 test-macos ← YOU ARE HERE\nmilestone 2"]
    PR3["#459 test-windows\nmilestone 3"]
    main --> PR2 --> PR3
    style PR2 fill:#ffd700,color:#000
```

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [x] Tests added and all succeed — verified green on CircleCI
- [x] Linted
- [ ] CHANGELOG.md updated — N/A, CI-only change
- [ ] README.md updated, if user-facing — N/A

### Screenshots / GIFs

N/A — CI config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
