### PR TITLE
ci: add test-windows job to CircleCI CICD workflow [IDE-2497]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,10 @@ jobs:
           command: |
             choco install temurin17 -y --no-progress
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - restore_cache:
+          name: Restore Maven/Tycho cache
+          keys:
+            - &m2-windows-cache-key m2-windows--pom.xml-{{ checksum "pom.xml" }}--plugin/pom.xml-{{ checksum "plugin/pom.xml" }}--tests/pom.xml-{{ checksum "tests/pom.xml" }}--target-platform/target-platform.target-{{ checksum "target-platform/target-platform.target" }}
       - run:
           name: Maven verify
           shell: powershell.exe -ExecutionPolicy Bypass
@@ -98,6 +102,11 @@ jobs:
             $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
             .\mvnw.cmd clean verify -DtrimStackTrace=false
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - save_cache:
+          name: Save Maven/Tycho cache
+          key: *m2-windows-cache-key
+          paths:
+            - C:\Users\circleci\.m2\repository
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,14 +79,19 @@ jobs:
       - checkout
       # Tycho/Mockito require JDK 17 specifically (JDK 21+ breaks Mockito's inline-mock
       # byte-buddy agent), and the JDK bundled with the Windows machine image isn't
-      # guaranteed to be 17. Install and verify share one step because CircleCI's Windows
-      # PowerShell has no BASH_ENV equivalent for propagating env vars across steps.
+      # guaranteed to be 17.
       - run:
-          name: Install Temurin JDK 17 and Maven verify
+          name: Install Temurin JDK 17
           shell: powershell.exe -ExecutionPolicy Bypass
           command: |
             choco install temurin17 -y --no-progress
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - run:
+          name: Maven verify
+          shell: powershell.exe -ExecutionPolicy Bypass
+          command: |
+            # choco install temurin17 does not set JAVA_HOME by default (FeatureJavaHome
+            # is opt-in, unlike FeatureEnvironment/PATH) -- resolve it from disk instead.
             $jdkHome = (Get-ChildItem "C:\Program Files\Eclipse Adoptium" -Directory -Filter "jdk-17*" | Select-Object -First 1).FullName
             if (-not $jdkHome) { Write-Error "Temurin 17 install not found under Eclipse Adoptium"; exit 1 }
             $env:JAVA_HOME = $jdkHome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,29 @@ jobs:
           paths:
             - ~/.m2/repository
 
+  test-windows:
+    resource_class: windows.medium
+    machine:
+      image: windows-server-2022-gui:current
+    steps:
+      - checkout
+      # Tycho/Mockito require JDK 17 specifically (JDK 21+ breaks Mockito's inline-mock
+      # byte-buddy agent), and the JDK bundled with the Windows machine image isn't
+      # guaranteed to be 17. Install and verify share one step because CircleCI's Windows
+      # PowerShell has no BASH_ENV equivalent for propagating env vars across steps.
+      - run:
+          name: Install Temurin JDK 17 and Maven verify
+          shell: powershell.exe -ExecutionPolicy Bypass
+          command: |
+            choco install temurin17 -y --no-progress
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            $jdkHome = (Get-ChildItem "C:\Program Files\Eclipse Adoptium" -Directory -Filter "jdk-17*" | Select-Object -First 1).FullName
+            if (-not $jdkHome) { Write-Error "Temurin 17 install not found under Eclipse Adoptium"; exit 1 }
+            $env:JAVA_HOME = $jdkHome
+            $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
+            .\mvnw.cmd clean verify -DtrimStackTrace=false
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
 workflows:
   version: 2
   CICD:
@@ -90,3 +113,4 @@ workflows:
 
       - test-linux
       - test-macos
+      - test-windows


### PR DESCRIPTION
### Description

Milestone 3 of the CircleCI test migration (IDE-2497). Adds a `test-windows` job running the same `./mvnw clean verify -DtrimStackTrace=false` as `test-linux`/`test-macos`, on CircleCI's `windows-server-2022-gui` machine executor, installing Temurin JDK 17 via Chocolatey.

Known, accepted non-blocking items (reviewed, not fixed):
- `machine: image: windows-server-2022-gui:current` uses a floating tag, unlike the pinned `test-linux`/`test-macos` images — accepted, matches CircleCI's own convention for Windows images.
- A comment above the install step bundles two rationales into one block — accepted as a documentation nit.

Milestone 1 (`test-linux`, PR #457) has merged into `main`. Stacked on #458 (`test-macos`, verified green on CircleCI). `test-windows` has been observed green on CircleCI, including a cache-hit re-run.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR2["#458 test-macos\nmilestone 2"]
    PR3["#459 test-windows ← YOU ARE HERE\nmilestone 3"]
    main --> PR2 --> PR3
    style PR3 fill:#ffd700,color:#000
```

**Depends on:** #458

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [x] Tests added and all succeed — verified green on CircleCI
- [x] Linted
- [ ] CHANGELOG.md updated — N/A, CI-only change
- [ ] README.md updated, if user-facing — N/A

### Screenshots / GIFs

N/A — CI config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no runtime or application code changes, with behavior aligned to existing cross-platform verify jobs.
> 
> **Overview**
> Adds a **Windows** leg to the CircleCI test migration: a new `test-windows` job runs the same `mvnw clean verify` as Linux/macOS on a `windows-server-2022-gui` machine executor.
> 
> The job installs **Temurin JDK 17** with Chocolatey (matching the macOS rationale for Tycho/Mockito), resolves `JAVA_HOME` manually because the Chocolatey package does not set it, restores/saves a **Windows-specific Maven/Tycho cache** under `C:\Users\circleci\.m2\repository`, and is wired into the **CICD** workflow next to `test-linux` and `test-macos`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 183080c4cca837d90de0d2cfbc4b21684d1a3851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->